### PR TITLE
Save stop place topographic places by ref

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/rest/graphql/mappers/StopPlaceMapper.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/graphql/mappers/StopPlaceMapper.java
@@ -27,9 +27,11 @@ import org.rutebanken.tiamat.model.SiteRefStructure;
 import org.rutebanken.tiamat.model.StopPlace;
 import org.rutebanken.tiamat.model.StopTypeEnumeration;
 import org.rutebanken.tiamat.model.TelecabinSubmodeEnumeration;
+import org.rutebanken.tiamat.model.TopographicPlace;
 import org.rutebanken.tiamat.model.TramSubmodeEnumeration;
 import org.rutebanken.tiamat.model.VehicleModeEnumeration;
 import org.rutebanken.tiamat.model.WaterSubmodeEnumeration;
+import org.rutebanken.tiamat.repository.TopographicPlaceRepository;
 import org.rutebanken.tiamat.rest.graphql.scalars.TransportModeScalar;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,12 +43,14 @@ import java.util.Map;
 
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.ADJACENT_SITES;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.ENTITY_REF_REF;
+import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.ID;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.PARENT_SITE_REF;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.PRIVATE_CODE;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.PUBLIC_CODE;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.QUAYS;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.STOP_PLACE_TYPE;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.SUBMODE;
+import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.TOPOGRAPHIC_PLACE;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.TRANSPORT_MODE;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.TYPE;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.VALID_BETWEEN;
@@ -69,6 +73,9 @@ public class StopPlaceMapper {
 
     @Autowired
     private ValidBetweenMapper validBetweenMapper;
+
+    @Autowired
+    private TopographicPlaceRepository topographicPlaceRepository;
 
     /**
      * @param input
@@ -123,6 +130,14 @@ public class StopPlaceMapper {
             }
             stopPlace.getPrivateCode().setType((String) privateCodeInputMap.get(TYPE));
             stopPlace.getPrivateCode().setValue((String) privateCodeInputMap.get(VALUE));
+            isUpdated = true;
+        }
+
+        if (input.get(TOPOGRAPHIC_PLACE) != null) {
+            Map topographicPlaceInputMap = (Map) input.get(TOPOGRAPHIC_PLACE);
+            String topographicPlaceRef = (String) topographicPlaceInputMap.get(ID);
+            TopographicPlace topographicPlace = topographicPlaceRepository.findFirstByNetexIdOrderByVersionDesc(topographicPlaceRef);
+            stopPlace.setTopographicPlace(topographicPlace);
             isUpdated = true;
         }
 

--- a/src/main/java/org/rutebanken/tiamat/rest/graphql/types/CustomGraphQLTypes.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/graphql/types/CustomGraphQLTypes.java
@@ -695,12 +695,6 @@ public class CustomGraphQLTypes {
             .field(newInputObjectField()
                     .name(ID)
                     .type(GraphQLString))
-            .field(newInputObjectField()
-                    .name(TOPOGRAPHIC_PLACE_TYPE)
-                    .type(topographicPlaceTypeEnum))
-            .field(newInputObjectField()
-                    .name(NAME)
-                    .type(embeddableMultiLingualStringInputObjectType))
             .build();
 
     public static GraphQLInputObjectType transferDurationInputObjectType = GraphQLInputObjectType.newInputObject()


### PR DESCRIPTION
Use a direct reference string when saving associated topographic places for stop places.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-tiamat/16)
<!-- Reviewable:end -->
