### PR TITLE
Add Hazelcast config to application.properties

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,6 +30,11 @@ netex.import.enabled.types=MERGE,INITIAL,ID_MATCH,MATCH
 hazelcast.performance.monitoring.enabled=true
 hazelcast.performance.monitoring.delay.seconds=2
 
+tiamat.hazelcast.service-name=hslTiamat
+tiamat.hazelcast.namespace=hslTiamat
+tiamat.hazelcast.kubernetes.enabled=false
+tiamat.hazelcast.cluster.name=${tiamat.hazelcast.cluster:hslTiamat}
+
 management.endpoints.web.exposure.include=info,env,metrics,health
 management.endpoints.prometheus.enabled=true
 management.metrics.endpoint.export.prometheus.enabled=true


### PR DESCRIPTION
Add Hazelcast configuration to application.properties.
Allow separating clusters by reading cluster name from TIAMAT_HAZELCAST_CLUSTER environment variable if it is present.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-tiamat/17)
<!-- Reviewable:end -->
