### PR TITLE
Ensure unique group of stop places names

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/exception/HSLErrorCodeEnumeration.java
+++ b/src/main/java/org/rutebanken/tiamat/exception/HSLErrorCodeEnumeration.java
@@ -1,0 +1,6 @@
+package org.rutebanken.tiamat.exception;
+
+public enum HSLErrorCodeEnumeration {
+    GROUP_OF_STOP_PLACES_UNIQUE_NAME,
+    GROUP_OF_STOP_PLACES_UNIQUE_DESCRIPTION
+}

--- a/src/main/resources/db/migration/V46.7__group_of_stop_places_name_constraints.sql
+++ b/src/main/resources/db/migration/V46.7__group_of_stop_places_name_constraints.sql
@@ -1,0 +1,39 @@
+CREATE OR REPLACE FUNCTION check_group_of_stop_places_unique_names()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- Find if there are any groups of stop places with the same name with overlapping validity periods
+    IF EXISTS (
+        SELECT 1
+        FROM group_of_stop_places gosp
+        WHERE gosp.name_value = NEW.name_value
+        AND gosp.version = (
+            SELECT MAX(version)
+            FROM group_of_stop_places
+            WHERE netex_id = gosp.netex_id
+        )
+        AND tstzrange(gosp.from_date, gosp.to_date, '[)') && tstzrange(NEW.from_date, NEW.to_date, '[)')
+    ) THEN
+        RAISE EXCEPTION 'GROUP_OF_STOP_PLACES_UNIQUE_NAME : Name % already exists for groups of stop places.', NEW.name_value;
+    END IF;
+    -- Find if there are any groups of stop places with the same description with overlapping validity periods
+    IF EXISTS (
+        SELECT 1
+        FROM group_of_stop_places gosp
+        WHERE gosp.description_value = NEW.description_value
+        AND gosp.version = (
+            SELECT MAX(version)
+            FROM group_of_stop_places
+            WHERE netex_id = gosp.netex_id
+        )
+        AND tstzrange(gosp.from_date, gosp.to_date, '[)') && tstzrange(NEW.from_date, NEW.to_date, '[)')
+    ) THEN
+        RAISE EXCEPTION 'GROUP_OF_STOP_PLACES_UNIQUE_DESCRIPTION : Description % already exists for groups of stop places.', NEW.description_value;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER group_of_stop_places_unique_names_trigger
+BEFORE INSERT OR UPDATE ON group_of_stop_places
+FOR EACH ROW
+EXECUTE FUNCTION check_group_of_stop_places_unique_names();

--- a/src/test/java/org/rutebanken/tiamat/model/GroupOfStopPlacesTest.java
+++ b/src/test/java/org/rutebanken/tiamat/model/GroupOfStopPlacesTest.java
@@ -1,10 +1,15 @@
 package org.rutebanken.tiamat.model;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import org.junit.Test;
 import org.rutebanken.tiamat.TiamatIntegrationTest;
+import org.springframework.orm.jpa.JpaSystemException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
 
 public class GroupOfStopPlacesTest extends TiamatIntegrationTest {
@@ -68,4 +73,141 @@ public class GroupOfStopPlacesTest extends TiamatIntegrationTest {
                 .contains(stopPlace.getNetexId());
     }
 
+
+    @Test
+    public void groupOfStopPlacesUniqueNameTest() {
+
+        Instant validityStart = Instant.now();
+        Instant validityEnd = validityStart.plusSeconds(60*60*24*7); // Week of seconds
+
+        StopPlace stopPlace = new StopPlace(new EmbeddableMultilingualString("Stop place 1"));
+        stopPlace.setVersion(1L);
+        stopPlace = stopPlaceRepository.save(stopPlace);
+
+        StopPlace stopPlace2 = new StopPlace(new EmbeddableMultilingualString("Stop place 2"));
+        stopPlace2.setVersion(1L);
+        stopPlace2 = stopPlaceRepository.save(stopPlace2);
+
+        String groupName = "Unique name for group of stop places";
+        GroupOfStopPlaces groupOfStopPlaces = new GroupOfStopPlaces(new EmbeddableMultilingualString(groupName));
+        groupOfStopPlaces.getMembers().add(new StopPlaceReference(stopPlace.getNetexId()));
+        groupOfStopPlaces.setValidBetween(new ValidBetween(validityStart, validityEnd));
+        groupOfStopPlacesRepository.save(groupOfStopPlaces);
+
+        GroupOfStopPlaces groupOfStopPlaces2 = new GroupOfStopPlaces(new EmbeddableMultilingualString(groupName));
+        groupOfStopPlaces2.getMembers().add(new StopPlaceReference(stopPlace2.getNetexId()));
+        groupOfStopPlaces2.setValidBetween(new ValidBetween(validityStart, validityEnd));
+        var thrown = catchThrowableOfType(() -> groupOfStopPlacesRepository.save(groupOfStopPlaces2), JpaSystemException.class);
+
+        assertThat(thrown.getMessage()).contains("Name " + groupName + " already exists for groups of stop places.");
+    }
+
+    @Test
+    public void groupOfStopPlacesUniqueDescriptionTest() {
+
+        Instant validityStart = Instant.now();
+        Instant validityEnd = validityStart.plusSeconds(60*60*24*7); // Week of seconds
+
+        StopPlace stopPlace = new StopPlace(new EmbeddableMultilingualString("Stop place 1"));
+        stopPlace.setVersion(1L);
+        stopPlace = stopPlaceRepository.save(stopPlace);
+
+        StopPlace stopPlace2 = new StopPlace(new EmbeddableMultilingualString("Stop place 2"));
+        stopPlace2.setVersion(1L);
+        stopPlace2 = stopPlaceRepository.save(stopPlace2);
+
+        String groupName = "Stop area 1";
+        String description = "Unique description";
+        GroupOfStopPlaces groupOfStopPlaces = new GroupOfStopPlaces(new EmbeddableMultilingualString(groupName));
+        groupOfStopPlaces.setDescription(new EmbeddableMultilingualString(description));
+        groupOfStopPlaces.getMembers().add(new StopPlaceReference(stopPlace.getNetexId()));
+        groupOfStopPlaces.setValidBetween(new ValidBetween(validityStart, validityEnd));
+        groupOfStopPlacesRepository.save(groupOfStopPlaces);
+
+        String groupName2 = "Stop area 2";
+        GroupOfStopPlaces groupOfStopPlaces2 = new GroupOfStopPlaces(new EmbeddableMultilingualString(groupName2));
+        groupOfStopPlaces2.setDescription(new EmbeddableMultilingualString(description));
+        groupOfStopPlaces2.getMembers().add(new StopPlaceReference(stopPlace2.getNetexId()));
+        groupOfStopPlaces2.setValidBetween(new ValidBetween(validityStart, validityEnd));
+        var thrown = catchThrowableOfType(() -> groupOfStopPlacesRepository.save(groupOfStopPlaces2), JpaSystemException.class);
+
+        assertThat(thrown.getMessage()).contains("Description " + description + " already exists for groups of stop places.");
+    }
+
+    @Test
+    public void allowSameNameForOldVersions() {
+        Instant validityStart = Instant.now();
+        Instant validityEnd = validityStart.plusSeconds(60*60*24*7); // Week of seconds
+
+        StopPlace stopPlace = new StopPlace(new EmbeddableMultilingualString("Stop place 1"));
+        stopPlace.setVersion(1L);
+        stopPlace = stopPlaceRepository.save(stopPlace);
+
+        StopPlace stopPlace2 = new StopPlace(new EmbeddableMultilingualString("Stop place 2"));
+        stopPlace2.setVersion(1L);
+        stopPlace2 = stopPlaceRepository.save(stopPlace2);
+
+        StopPlace stopPlace3 = new StopPlace(new EmbeddableMultilingualString("Stop place 3"));
+        stopPlace3.setVersion(1L);
+        stopPlace3 = stopPlaceRepository.save(stopPlace3);
+
+        String oldGroupName = "Old Stop Area";
+        String oldGroupDescription = "Old Stop Description";
+        GroupOfStopPlaces oldGroupOfStopPlaces = new GroupOfStopPlaces(new EmbeddableMultilingualString(oldGroupName));
+        oldGroupOfStopPlaces.setDescription(new EmbeddableMultilingualString(oldGroupDescription));
+        oldGroupOfStopPlaces.setVersion(1L);
+        oldGroupOfStopPlaces.setNetexId("NSR:GroupOfStopAreas:50");
+        oldGroupOfStopPlaces.getMembers().add(new StopPlaceReference(stopPlace.getNetexId()));
+        oldGroupOfStopPlaces.setValidBetween(new ValidBetween(validityStart, validityEnd));
+        groupOfStopPlacesRepository.save(oldGroupOfStopPlaces);
+
+        GroupOfStopPlaces newGroupOfStopPlaces = new GroupOfStopPlaces(new EmbeddableMultilingualString(oldGroupName));
+        newGroupOfStopPlaces.setName(new EmbeddableMultilingualString("New Stop Area"));
+        newGroupOfStopPlaces.setDescription(new EmbeddableMultilingualString("New Stop Description"));
+        newGroupOfStopPlaces.setVersion(2L);
+        newGroupOfStopPlaces.setNetexId("NSR:GroupOfStopAreas:50");
+        newGroupOfStopPlaces.getMembers().add(new StopPlaceReference(stopPlace2.getNetexId()));
+        newGroupOfStopPlaces.setValidBetween(new ValidBetween(validityStart, validityEnd));
+        groupOfStopPlacesRepository.save(newGroupOfStopPlaces);
+
+        GroupOfStopPlaces groupOfStopPlaces2 = new GroupOfStopPlaces(new EmbeddableMultilingualString(oldGroupName));
+        groupOfStopPlaces2.setDescription(new EmbeddableMultilingualString(oldGroupDescription));
+        groupOfStopPlaces2.getMembers().add(new StopPlaceReference(stopPlace3.getNetexId()));
+        groupOfStopPlaces2.setValidBetween(new ValidBetween(validityStart, validityEnd));
+
+        assertThatNoException().isThrownBy(() -> groupOfStopPlacesRepository.save(groupOfStopPlaces2));
+    }
+
+    @Test
+    public void allowSameNameForNonOverlappingDates() {
+        StopPlace stopPlace = new StopPlace(new EmbeddableMultilingualString("Stop place 1"));
+        stopPlace.setVersion(1L);
+        stopPlace = stopPlaceRepository.save(stopPlace);
+
+        StopPlace stopPlace2 = new StopPlace(new EmbeddableMultilingualString("Stop place 2"));
+        stopPlace2.setVersion(1L);
+        stopPlace2 = stopPlaceRepository.save(stopPlace2);
+
+        String groupName = "Timed area";
+        String groupDescription = "Timed description";
+
+        LocalDateTime currentDate = LocalDateTime.now();
+        LocalDateTime startDate = currentDate.minusDays(10);
+        LocalDateTime endDate = currentDate.plusDays(10);
+
+        GroupOfStopPlaces groupOfStopPlaces1 = new GroupOfStopPlaces(new EmbeddableMultilingualString(groupName));
+        groupOfStopPlaces1.setDescription(new EmbeddableMultilingualString(groupDescription));
+        groupOfStopPlaces1.setVersion(1L);
+        groupOfStopPlaces1.getMembers().add(new StopPlaceReference(stopPlace.getNetexId()));
+        groupOfStopPlaces1.setValidBetween(new ValidBetween(startDate.toInstant(ZoneOffset.UTC), currentDate.toInstant(ZoneOffset.UTC)));
+        groupOfStopPlacesRepository.save(groupOfStopPlaces1);
+
+        GroupOfStopPlaces groupOfStopPlaces2 = new GroupOfStopPlaces(new EmbeddableMultilingualString(groupName));
+        groupOfStopPlaces2.setDescription(new EmbeddableMultilingualString(groupDescription));
+        groupOfStopPlaces2.setVersion(1L);
+        groupOfStopPlaces2.getMembers().add(new StopPlaceReference(stopPlace2.getNetexId()));
+        groupOfStopPlaces2.setValidBetween(new ValidBetween(currentDate.toInstant(ZoneOffset.UTC), endDate.toInstant(ZoneOffset.UTC)));
+
+        assertThatNoException().isThrownBy(() -> groupOfStopPlacesRepository.save(groupOfStopPlaces2));
+    }
 }

--- a/src/test/java/org/rutebanken/tiamat/versioning/save/GroupOfStopPlacesSaverServiceTest.java
+++ b/src/test/java/org/rutebanken/tiamat/versioning/save/GroupOfStopPlacesSaverServiceTest.java
@@ -116,7 +116,7 @@ public class GroupOfStopPlacesSaverServiceTest extends TiamatIntegrationTest {
 
         GroupOfStopPlaces changed = new GroupOfStopPlaces();
         changed.setNetexId(saved.getNetexId());
-        changed.setName(new EmbeddableMultilingualString("name"));
+        changed.setName(new EmbeddableMultilingualString("name2"));
         changed.setPurposeOfGrouping(saved.getPurposeOfGrouping());
         changed.getMembers().add(new StopPlaceReference(stopPlace.getNetexId()));
         changed.getMembers().add(new StopPlaceReference(stopPlace2.getNetexId()));


### PR DESCRIPTION
Add database constraints to ensure the newest versions of group_of_stop_places have unique name_value and
description_value fields.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-tiamat/43)
<!-- Reviewable:end -->
