### PR TITLE
Allow same name for new version of same group

### DIFF
--- a/src/main/resources/db/migration/V46.7__group_of_stop_places_name_constraints.sql
+++ b/src/main/resources/db/migration/V46.7__group_of_stop_places_name_constraints.sql
@@ -9,7 +9,7 @@ BEGIN
         AND gosp.version = (
             SELECT MAX(version)
             FROM group_of_stop_places
-            WHERE netex_id = gosp.netex_id
+            WHERE netex_id = gosp.netex_id AND netex_id != NEW.netex_id
         )
         AND tstzrange(gosp.from_date, gosp.to_date, '[)') && tstzrange(NEW.from_date, NEW.to_date, '[)')
     ) THEN
@@ -23,7 +23,7 @@ BEGIN
         AND gosp.version = (
             SELECT MAX(version)
             FROM group_of_stop_places
-            WHERE netex_id = gosp.netex_id
+            WHERE netex_id = gosp.netex_id AND netex_id != NEW.netex_id
         )
         AND tstzrange(gosp.from_date, gosp.to_date, '[)') && tstzrange(NEW.from_date, NEW.to_date, '[)')
     ) THEN


### PR DESCRIPTION
Fix a bug which did not allow the same name or description for a new version of the same group of stop places.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-tiamat/46)
<!-- Reviewable:end -->
