### PR TITLE
Use a new migration for fixed group uniqueness

### DIFF
--- a/src/main/resources/db/migration/V46.8__fixed_group_of_stop_places_name_constraints.sql
+++ b/src/main/resources/db/migration/V46.8__fixed_group_of_stop_places_name_constraints.sql
@@ -9,7 +9,7 @@ BEGIN
         AND gosp.version = (
             SELECT MAX(version)
             FROM group_of_stop_places
-            WHERE netex_id = gosp.netex_id
+            WHERE netex_id = gosp.netex_id AND netex_id != NEW.netex_id
         )
         AND tstzrange(gosp.from_date, gosp.to_date, '[)') && tstzrange(NEW.from_date, NEW.to_date, '[)')
     ) THEN
@@ -23,7 +23,7 @@ BEGIN
         AND gosp.version = (
             SELECT MAX(version)
             FROM group_of_stop_places
-            WHERE netex_id = gosp.netex_id
+            WHERE netex_id = gosp.netex_id AND netex_id != NEW.netex_id
         )
         AND tstzrange(gosp.from_date, gosp.to_date, '[)') && tstzrange(NEW.from_date, NEW.to_date, '[)')
     ) THEN
@@ -32,8 +32,3 @@ BEGIN
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
-
-CREATE TRIGGER group_of_stop_places_unique_names_trigger
-BEFORE INSERT OR UPDATE ON group_of_stop_places
-FOR EACH ROW
-EXECUTE FUNCTION check_group_of_stop_places_unique_names();


### PR DESCRIPTION
Rather than editing a previous migration, use a new migration for fixed name constraint.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-tiamat/47)
<!-- Reviewable:end -->
