### PR TITLE
Allow child stop place editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,8 @@ blobstore.local.folder=/tmp/local-gcs-storage/tiamat/export
 spring.profiles.active=local-blobstore,activemq
 
 
-
-
+# Should child stop places be able to keep the same name as the parent stop place
+allowSameNameForChild=false
 
 
 ```

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -105,7 +105,7 @@ management.security.enabled=false
 authorization.enabled=false
 rutebanken.kubernetes.enabled=false
 
-
+tiamat.multimodal.allowSameNameForChild=true
 
 
 


### PR DESCRIPTION
Allow editing of child stop places belonging to a multimodal stop place.
Add a property which determines if child stop names are cleared when they match the parent stop name.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-tiamat/50)
<!-- Reviewable:end -->
