### PR TITLE
Implement AlternativeNames properly for GroupsOfStopPlaces

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/model/EntityWithAlternativeNames.java
+++ b/src/main/java/org/rutebanken/tiamat/model/EntityWithAlternativeNames.java
@@ -1,0 +1,8 @@
+package org.rutebanken.tiamat.model;
+
+import java.util.List;
+
+public interface EntityWithAlternativeNames {
+    // Used List implementation has to be mutable
+    List<AlternativeName> getAlternativeNames();
+}

--- a/src/main/java/org/rutebanken/tiamat/model/GroupOfStopPlaces.java
+++ b/src/main/java/org/rutebanken/tiamat/model/GroupOfStopPlaces.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Set;
 
 @Entity
-public class GroupOfStopPlaces extends GroupOfEntities_VersionStructure {
+public class GroupOfStopPlaces extends GroupOfEntities_VersionStructure implements EntityWithAlternativeNames {
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<AlternativeName> alternativeNames = new ArrayList<>();

--- a/src/main/java/org/rutebanken/tiamat/model/SiteElement.java
+++ b/src/main/java/org/rutebanken/tiamat/model/SiteElement.java
@@ -28,7 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @MappedSuperclass
-public abstract class SiteElement extends AddressablePlace {
+public abstract class SiteElement extends AddressablePlace implements EntityWithAlternativeNames {
 
     @org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/org/rutebanken/tiamat/rest/graphql/mappers/SiteElementMapper.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/graphql/mappers/SiteElementMapper.java
@@ -45,12 +45,6 @@ public class SiteElementMapper {
     private static final Logger logger = LoggerFactory.getLogger(SiteElementMapper.class);
 
     @Autowired
-    private AlternativeNameMapper alternativeNameMapper;
-
-    @Autowired
-    private AlternativeNameUpdater alternativeNameUpdater;
-
-    @Autowired
     private AccessibilityLimitationMapper accessibilityLimitationMapper;
 
     @Autowired
@@ -65,17 +59,6 @@ public class SiteElementMapper {
     public boolean populate(Map input, SiteElement siteElement) {
 
         boolean isUpdated = false;
-
-        if (input.get(ALTERNATIVE_NAMES) != null) {
-            List alternativeNames = (List) input.get(ALTERNATIVE_NAMES);
-            List<AlternativeName> mappedAlternativeNames = alternativeNameMapper.mapAlternativeNames(alternativeNames);
-
-            if (alternativeNameUpdater.updateAlternativeNames(siteElement, mappedAlternativeNames)) {
-                isUpdated = true;
-            } else {
-                logger.info("AlternativeName not changed");
-            }
-        }
 
         if (input.get(GEOMETRY) != null) {
 

--- a/src/main/java/org/rutebanken/tiamat/rest/graphql/types/GroupOfStopPlacesObjectTypeCreator.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/graphql/types/GroupOfStopPlacesObjectTypeCreator.java
@@ -38,6 +38,7 @@ import org.springframework.stereotype.Component;
 import static graphql.Scalars.GraphQLString;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLObjectType.newObject;
+import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.ALTERNATIVE_NAMES;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.DESCRIPTION;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.GROUP_OF_STOP_PLACES_MEMBERS;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.NAME;
@@ -47,6 +48,7 @@ import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.SHORT_NAME;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.VALID_BETWEEN;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.VERSION;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.VERSION_COMMENT;
+import static org.rutebanken.tiamat.rest.graphql.types.CustomGraphQLTypes.alternativeNameObjectType;
 import static org.rutebanken.tiamat.rest.graphql.types.CustomGraphQLTypes.embeddableMultilingualStringObjectType;
 import static org.rutebanken.tiamat.rest.graphql.types.CustomGraphQLTypes.geometryFieldDefinition;
 import static org.rutebanken.tiamat.rest.graphql.types.CustomGraphQLTypes.netexIdFieldDefinition;
@@ -69,6 +71,9 @@ public class GroupOfStopPlacesObjectTypeCreator {
                 .field(newFieldDefinition()
                         .name(DESCRIPTION)
                         .type(embeddableMultilingualStringObjectType))
+                .field(newFieldDefinition()
+                        .name(ALTERNATIVE_NAMES)
+                        .type(new GraphQLList(alternativeNameObjectType)))
                 .field(newFieldDefinition()
                         .name(VERSION)
                         .type(GraphQLString))

--- a/src/main/java/org/rutebanken/tiamat/service/AlternativeNameUpdater.java
+++ b/src/main/java/org/rutebanken/tiamat/service/AlternativeNameUpdater.java
@@ -17,8 +17,8 @@ package org.rutebanken.tiamat.service;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.rutebanken.tiamat.model.AlternativeName;
+import org.rutebanken.tiamat.model.EntityWithAlternativeNames;
 import org.rutebanken.tiamat.model.NameTypeEnumeration;
-import org.rutebanken.tiamat.model.SiteElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -41,7 +41,7 @@ public class AlternativeNameUpdater {
      * @param alternativeNames incoming alternative names
      * @return if alternative names were updated
      */
-    public boolean updateAlternativeNames(SiteElement entity, List<AlternativeName> alternativeNames) {
+    public boolean updateAlternativeNames(EntityWithAlternativeNames entity, List<AlternativeName> alternativeNames) {
         final AtomicInteger matchedExisting = new AtomicInteger();
 
         avoidDuplicateTranslationsPerLanguage(alternativeNames);
@@ -85,7 +85,7 @@ public class AlternativeNameUpdater {
                 });
     }
 
-    private Optional<AlternativeName> matchExisting(SiteElement entity, AlternativeName incomingAlternativeName) {
+    private Optional<AlternativeName> matchExisting(EntityWithAlternativeNames entity, AlternativeName incomingAlternativeName) {
         return entity.getAlternativeNames()
                 .stream()
                 .filter(existingAlternativeName -> existingAlternativeName.getName().equals(incomingAlternativeName.getName())

--- a/src/test/java/org/rutebanken/tiamat/rest/graphql/GraphQLResourceGroupOfStopPlacesIntegrationTest.java
+++ b/src/test/java/org/rutebanken/tiamat/rest/graphql/GraphQLResourceGroupOfStopPlacesIntegrationTest.java
@@ -55,8 +55,9 @@ public class GraphQLResourceGroupOfStopPlacesIntegrationTest extends AbstractGra
         stopPlace2.setCentroid(geometryFactory.createPoint(new Coordinate(13, 61)));
         stopPlace2.setStopPlaceType(StopTypeEnumeration.TRAM_STATION);
         stopPlaceVersionedSaverService.saveNewVersion(stopPlace2);
-        
+
         var groupName = "Group name";
+        var groupSweName = "Gruppens namn";
         var versionComment = "VersionComment";
 
         Double lon =  Double.valueOf("10.111");
@@ -69,6 +70,10 @@ public class GraphQLResourceGroupOfStopPlacesIntegrationTest extends AbstractGra
                                     mutation {
                                     group: %s(GroupOfStopPlaces: {
                                         name: {value: "%s"},
+                                        alternativeNames: [{
+                                            name: { lang: "swe", value: "%s" },
+                                            nameType: translation
+                                        }],
                                         purposeOfGrouping: {ref: "%s"},
                                         versionComment: "%s",
                                         validBetween: {
@@ -108,11 +113,16 @@ public class GraphQLResourceGroupOfStopPlacesIntegrationTest extends AbstractGra
                                         stopPlaceType
                                       }
                                     }
+                                    alternativeNames {
+                                      name { lang, value }
+                                      nameType
+                                    }
                                   }
                                 }
                                 """.formatted(
                                                 MUTATE_GROUP_OF_STOP_PLACES,
                                                 groupName,
+                                                groupSweName,
                                                 purposeOfGrouping.getNetexId(),
                                                 versionComment,
                                                 startDate.toString(),
@@ -143,7 +153,10 @@ public class GraphQLResourceGroupOfStopPlacesIntegrationTest extends AbstractGra
                 .rootPath("data.group.members.find { it.id == '" + stopPlace1.getNetexId() + "'}")
                     .body("name", nullValue())
                     .body("stopPlaceType", equalTo(StopTypeEnumeration.BUS_STATION.value()))
-                    .body("version", equalTo(String.valueOf(stopPlace1.getVersion())));
+                    .body("version", equalTo(String.valueOf(stopPlace1.getVersion())))
+                .rootPath("data.group.alternativeNames.find { it.nameType == 'translation'}")
+                    .body("name.lang", equalTo("swe"))
+                    .body("name.value", equalTo(groupSweName));
     }
 
     @Test


### PR DESCRIPTION
### Add generic Interface for entities that have AlternativeNames
`SiteElement` and `GroupOfStopPlaces` now implement a generic
interface `EntityWithAlternativeNames` so that the alternative names
can be handled in both cases.


### Move AlternativeName updating to higher level
Now correctly handles all GroupsOfEntities that implement the new
`EntityWithAlternativeNames` interface.


### Add AlternativeNames to GroupOfStopPlaces output type


### Test AlternativeNames support in GroupsOfStopPlaces

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-tiamat/54)
<!-- Reviewable:end -->
