### PR TITLE
Improve views for newest Quay & Stop Place

### DIFF
--- a/src/main/resources/db/migration/R__0__view_helpers.sql
+++ b/src/main/resources/db/migration/R__0__view_helpers.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW stop_place_max_version AS
+SELECT DISTINCT ON (netex_id) netex_id, version, id
+FROM stop_place
+ORDER BY netex_id, version DESC;

--- a/src/main/resources/db/migration/R__view_for_newest_quay.sql
+++ b/src/main/resources/db/migration/R__view_for_newest_quay.sql
@@ -1,57 +1,81 @@
 DROP VIEW IF EXISTS quay_newest_version;
+DROP VIEW IF EXISTS quay_alt_name_by_type;
+DROP VIEW IF EXISTS quay_max_version;
+
+
+--- Separate max version selection to its own helper view
+--- to keep the main view as a simple SELECT+JOIN view.
+CREATE VIEW quay_max_version AS
+SELECT DISTINCT ON (netex_id) netex_id, version, id
+FROM quay
+ORDER BY netex_id, version DESC;
+
+
+--- Spread the join and the actual data table on single row →
+--- Allows us to join a singular alt name on the main view,
+--- without having to join in all quay_alternative_names rows.
+CREATE VIEW quay_alt_name_by_type AS
+SELECT qan.quay_id, an.name_type, an.name_lang, an.name_value
+FROM quay_alternative_names AS qan
+LEFT JOIN alternative_name AS an ON qan.alternative_names_id = an.id;
+
 
 CREATE VIEW quay_newest_version AS
-SELECT DISTINCT ON (q.netex_id) q.*,
-                                an.name_value        as location_swe,
-                                streetAddress.items  as street_address,
-                                priority.items       as priority,
-                                validityStart.items  as validity_start,
-                                validityEnd.items    as validity_end,
-                                ELYCode.items        as ely_code,
-                                postalCode.items     as postal_code,
-                                functionalArea.items as functional_area,
-                                sp.id                as stop_place_id,
-                                sp.version           as stop_place_version
+SELECT  q.*,
+        qanbt.name_value     AS location_swe,
+        streetAddress.items  AS street_address,
+        priority.items       AS priority,
+        validityStart.items  AS validity_start,
+        validityEnd.items    AS validity_end,
+        ELYCode.items        AS ely_code,
+        postalCode.items     AS postal_code,
+        functionalArea.items AS functional_area,
+        spmv.id              AS stop_place_id,
+        spmv.version         AS stop_place_version,
+        spmv.netex_id        AS stop_place_netex_id
 
 FROM quay AS q
 
-         INNER JOIN stop_place_quays AS spq ON spq.quays_id = q.id
+    INNER JOIN quay_max_version AS maxVersion ON q.id = maxVersion.id
 
-         INNER JOIN stop_place AS sp ON spq.stop_place_id = sp.id
+    INNER JOIN stop_place_quays AS spq ON spq.quays_id = q.id
 
-         LEFT JOIN quay_alternative_names AS qan
-                   ON q.id = qan.quay_id
-         LEFT JOIN alternative_name as an
-                   on qan.alternative_names_id = an.id AND an.name_type = 'OTHER' AND an.name_lang = 'swe'
+    --- When deleting a Quay, it is not removed from the DB, and it is not event
+    --- marked as soft deleted. Thus, by default 'SELECT FROM quay' also includes
+    --- all deleted quays which we do not want. -> Select only those quays, that
+    --- are still associated with some current version of a Stop Place.
+    INNER JOIN stop_place_max_version AS spmv ON spq.stop_place_id = spmv.id
 
-         LEFT JOIN quay_key_values AS qkvAddress
-                   ON q.id = qkvAddress.quay_id AND qkvAddress.key_values_key = 'streetAddress'
-         LEFT JOIN value_items AS streetAddress ON qkvAddress.key_values_id = streetAddress.value_id
+    --- These can technically contain multiple values -> Duplicate result rows.
+    --- But in practice these should never contain duplicates on our use cases.
+    --- Thus in name of performance assume they have a max one value.
+    LEFT JOIN quay_alt_name_by_type AS qanbt ON
+        q.id = qanbt.quay_id AND qanbt.name_type = 'OTHER' AND qanbt.name_lang = 'swe'
 
-         LEFT JOIN quay_key_values AS qkvPriority
-                   ON q.id = qkvPriority.quay_id AND qkvPriority.key_values_key = 'priority'
-         LEFT JOIN value_items AS priority ON qkvPriority.key_values_id = priority.value_id
+    LEFT JOIN quay_key_values AS qkvAddress ON
+        q.id = qkvAddress.quay_id AND qkvAddress.key_values_key = 'streetAddress'
+    LEFT JOIN value_items AS streetAddress ON qkvAddress.key_values_id = streetAddress.value_id
 
-         LEFT JOIN quay_key_values AS qkvValidityStart ON
-    q.id = qkvValidityStart.quay_id AND qkvValidityStart.key_values_key = 'validityStart'
-         LEFT JOIN value_items AS validityStart ON qkvValidityStart.key_values_id = validityStart.value_id
+    LEFT JOIN quay_key_values AS qkvPriority ON
+        q.id = qkvPriority.quay_id AND qkvPriority.key_values_key = 'priority'
+    LEFT JOIN value_items AS priority ON qkvPriority.key_values_id = priority.value_id
 
-         LEFT JOIN quay_key_values AS qkvValidityEnd ON
-    q.id = qkvValidityEnd.quay_id AND qkvValidityEnd.key_values_key = 'validityEnd'
-         LEFT JOIN value_items AS validityEnd ON qkvValidityEnd.key_values_id = validityEnd.value_id
+    LEFT JOIN quay_key_values AS qkvValidityStart ON
+        q.id = qkvValidityStart.quay_id AND qkvValidityStart.key_values_key = 'validityStart'
+    LEFT JOIN value_items AS validityStart ON qkvValidityStart.key_values_id = validityStart.value_id
 
-         LEFT JOIN quay_key_values AS qkvELYCode ON
-    q.id = qkvELYCode.quay_id AND qkvELYCode.key_values_key = 'elyNumber'
-         LEFT JOIN value_items AS ELYCode ON qkvELYCode.key_values_id = ELYCode.value_id
+    LEFT JOIN quay_key_values AS qkvValidityEnd ON
+        q.id = qkvValidityEnd.quay_id AND qkvValidityEnd.key_values_key = 'validityEnd'
+    LEFT JOIN value_items AS validityEnd ON qkvValidityEnd.key_values_id = validityEnd.value_id
 
-         LEFT JOIN quay_key_values AS qkvPostalCode ON
-    q.id = qkvPostalCode.quay_id AND qkvPostalCode.key_values_key = 'postalCode'
-         LEFT JOIN value_items AS postalCode ON qkvPostalCode.key_values_id = postalCode.value_id
+    LEFT JOIN quay_key_values AS qkvELYCode ON
+        q.id = qkvELYCode.quay_id AND qkvELYCode.key_values_key = 'elyNumber'
+    LEFT JOIN value_items AS ELYCode ON qkvELYCode.key_values_id = ELYCode.value_id
 
-         LEFT JOIN quay_key_values AS qkvFunctionalArea ON
-    q.id = qkvFunctionalArea.quay_id AND qkvFunctionalArea.key_values_key = 'functionalArea'
-         LEFT JOIN value_items AS functionalArea ON qkvFunctionalArea.key_values_id = functionalArea.value_id
+    LEFT JOIN quay_key_values AS qkvPostalCode ON
+        q.id = qkvPostalCode.quay_id AND qkvPostalCode.key_values_key = 'postalCode'
+    LEFT JOIN value_items AS postalCode ON qkvPostalCode.key_values_id = postalCode.value_id
 
-
-ORDER BY netex_id ASC, version DESC
-
+    LEFT JOIN quay_key_values AS qkvFunctionalArea ON
+        q.id = qkvFunctionalArea.quay_id AND qkvFunctionalArea.key_values_key = 'functionalArea'
+    LEFT JOIN value_items AS functionalArea ON qkvFunctionalArea.key_values_id = functionalArea.value_id;

--- a/src/main/resources/db/migration/R__view_for_newest_stop_place_versions.sql
+++ b/src/main/resources/db/migration/R__view_for_newest_stop_place_versions.sql
@@ -1,9 +1,8 @@
 DROP VIEW IF EXISTS stop_place_newest_version;
 
 CREATE VIEW stop_place_newest_version AS
-SELECT DISTINCT ON (sp.netex_id)
+SELECT
     sp.*,
-    quay.public_code AS quay_public_code,
     streetAddress.items AS street_address,
     priority.items AS priority,
     validityStart.items AS validity_start,
@@ -11,24 +10,24 @@ SELECT DISTINCT ON (sp.netex_id)
 
 FROM stop_place AS sp
 
-         INNER JOIN stop_place_quays AS spq ON sp.id = spq.stop_place_id
-         INNER JOIN quay ON spq.quays_id = quay.id
+    INNER JOIN stop_place_max_version AS maxVersion ON
+        sp.netex_id = maxVersion.netex_id AND sp.version = maxVersion.version
 
-         LEFT JOIN stop_place_key_values AS spkvAddress ON
-             sp.id = spkvAddress.stop_place_id AND spkvAddress.key_values_key = 'streetAddress'
-         LEFT JOIN value_items AS streetAddress ON spkvAddress.key_values_id = streetAddress.value_id
+    --- These can technically contain multiple values -> Duplicate result rows.
+    --- But in practice these should never contain duplicates on our use cases.
+    --- Thus in name of performance assume they have a max one value.
+    LEFT JOIN stop_place_key_values AS spkvAddress ON
+        sp.id = spkvAddress.stop_place_id AND spkvAddress.key_values_key = 'streetAddress'
+    LEFT JOIN value_items AS streetAddress ON spkvAddress.key_values_id = streetAddress.value_id
 
-         LEFT JOIN stop_place_key_values AS spkvPriority ON
-            sp.id = spkvPriority.stop_place_id AND spkvPriority.key_values_key = 'priority'
-         LEFT JOIN value_items AS priority ON spkvPriority.key_values_id = priority.value_id
+    LEFT JOIN stop_place_key_values AS spkvPriority ON
+        sp.id = spkvPriority.stop_place_id AND spkvPriority.key_values_key = 'priority'
+    LEFT JOIN value_items AS priority ON spkvPriority.key_values_id = priority.value_id
 
-         LEFT JOIN stop_place_key_values AS spkvValidityStart ON
-            sp.id = spkvValidityStart.stop_place_id AND spkvValidityStart.key_values_key = 'validityStart'
-         LEFT JOIN value_items AS validityStart ON spkvValidityStart.key_values_id = validityStart.value_id
+    LEFT JOIN stop_place_key_values AS spkvValidityStart ON
+        sp.id = spkvValidityStart.stop_place_id AND spkvValidityStart.key_values_key = 'validityStart'
+    LEFT JOIN value_items AS validityStart ON spkvValidityStart.key_values_id = validityStart.value_id
 
-         LEFT JOIN stop_place_key_values AS spkvValidityEnd ON
-            sp.id = spkvValidityEnd.stop_place_id AND spkvValidityEnd.key_values_key = 'validityEnd'
-         LEFT JOIN value_items AS validityEnd ON spkvValidityEnd.key_values_id = validityEnd.value_id
-
-ORDER BY netex_id ASC, version DESC
-
+    LEFT JOIN stop_place_key_values AS spkvValidityEnd ON
+        sp.id = spkvValidityEnd.stop_place_id AND spkvValidityEnd.key_values_key = 'validityEnd'
+    LEFT JOIN value_items AS validityEnd ON spkvValidityEnd.key_values_id = validityEnd.value_id;


### PR DESCRIPTION
* Stop Place:
  1. Extracted max version selection into another reusable view. This new view only select the version info from the stop_place.
  2. Made assumption about KeyValues only ever having single values. As that is our use case, multiple values would be a invalid date and should be fixed on the DB.
  3. Improved the view performance with the help of points 1. & 2. The view no longer contains any grouping or sorting logic, and is simply a view that joins in other tables.

* Quay:
  1. Extracted max version selection into another reusable view.
  2. Made assumption about KeyValues only ever having single values.
  3. Improved the view performance with the help of points 1. & 2. The view no longer contains any grouping or sorting logic.
  4. Added in a join to the max version of StopPlace: When a Quay is "deleted" it simply unassociated from a StopPlace and the Quay itself stays in the DB. Thus to "filter out deleted" quays, we must only take in Quays that belong to some StopPlace's max version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-tiamat/71)
<!-- Reviewable:end -->
