### PR TITLE
Support custom InfoSpot & Poster sizes

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/model/InfoSpot.java
+++ b/src/main/java/org/rutebanken/tiamat/model/InfoSpot.java
@@ -19,4 +19,8 @@ public class InfoSpot extends InfoSpot_VersionStructure implements Serializable 
 
     @Serial
     private static final long serialVersionUID = 2459437438760752116L;
+
+    public PosterSizeEnumeration getPosterPlaceSize() {
+        return PosterSizeEnumeration.fromSize(getWidth(), getHeight());
+    }
 }

--- a/src/main/java/org/rutebanken/tiamat/model/InfoSpotPoster.java
+++ b/src/main/java/org/rutebanken/tiamat/model/InfoSpotPoster.java
@@ -12,4 +12,8 @@ public class InfoSpotPoster extends InfoSpotPoster_VersionStructure implements S
 
     @Serial
     private static final long serialVersionUID = 504687562412240224L;
+
+    public PosterSizeEnumeration getPosterSize() {
+        return PosterSizeEnumeration.fromSize(getWidth(), getHeight());
+    }
 }

--- a/src/main/java/org/rutebanken/tiamat/model/InfoSpotPoster_VersionStructure.java
+++ b/src/main/java/org/rutebanken/tiamat/model/InfoSpotPoster_VersionStructure.java
@@ -1,7 +1,5 @@
 package org.rutebanken.tiamat.model;
 
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.MappedSuperclass;
 
 @MappedSuperclass
@@ -9,8 +7,8 @@ public class InfoSpotPoster_VersionStructure extends DataManagedObjectStructure 
     private String label;
     private String lines;
 
-    @Enumerated(EnumType.STRING)
-    private PosterSizeEnumeration posterSize;
+    private Integer width;
+    private Integer height;
 
     public String getLabel() {
         return label;
@@ -28,11 +26,19 @@ public class InfoSpotPoster_VersionStructure extends DataManagedObjectStructure 
         this.lines = lines;
     }
 
-    public PosterSizeEnumeration getPosterSize() {
-        return posterSize;
+    public Integer getWidth() {
+        return width;
     }
 
-    public void setPosterSize(PosterSizeEnumeration posterSize) {
-        this.posterSize = posterSize;
+    public void setWidth(Integer width) {
+        this.width = width;
+    }
+
+    public Integer getHeight() {
+        return height;
+    }
+
+    public void setHeight(Integer height) {
+        this.height = height;
     }
 }

--- a/src/main/java/org/rutebanken/tiamat/model/InfoSpot_VersionStructure.java
+++ b/src/main/java/org/rutebanken/tiamat/model/InfoSpot_VersionStructure.java
@@ -21,8 +21,8 @@ public class InfoSpot_VersionStructure extends Zone_VersionStructure {
     private InfoSpotTypeEnumeration infoSpotType;
     private String label;
     private String purpose;
-    @Enumerated(EnumType.STRING)
-    private PosterSizeEnumeration posterPlaceSize;
+    private Integer width;
+    private Integer height;
     private Boolean backlight;
     private String maintenance;
     private String zoneLabel;
@@ -69,12 +69,20 @@ public class InfoSpot_VersionStructure extends Zone_VersionStructure {
         this.purpose = purpose;
     }
 
-    public PosterSizeEnumeration getPosterPlaceSize() {
-        return posterPlaceSize;
+    public Integer getWidth() {
+        return width;
     }
 
-    public void setPosterPlaceSize(PosterSizeEnumeration posterPlaceSize) {
-        this.posterPlaceSize = posterPlaceSize;
+    public void setWidth(Integer width) {
+        this.width = width;
+    }
+
+    public Integer getHeight() {
+        return height;
+    }
+
+    public void setHeight(Integer height) {
+        this.height = height;
     }
 
     public Boolean getBacklight() {

--- a/src/main/java/org/rutebanken/tiamat/model/PosterSizeEnumeration.java
+++ b/src/main/java/org/rutebanken/tiamat/model/PosterSizeEnumeration.java
@@ -1,18 +1,51 @@
 package org.rutebanken.tiamat.model;
 
+import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.HEIGHT;
+import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.WIDTH;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * This enum exists as a temporary compatability helper, as we do not have versioned
+ * microservice dependencies or monorepo, we need to convert back and forth with the
+ * enum until, UI and E2E tests all use the new width/height interface.
+ */
 public enum PosterSizeEnumeration {
-    A3("a3"),
-    A4("a4"),
-    CM80x120("cm80x120");
+    A3("a3", 297, 420),
+    A4("a4", 210, 297),
+    CM80x120("cm80x120", 800, 1200);
 
     private final String value;
 
-    PosterSizeEnumeration(String v) {
+    private final int width;
+    private final int height;
+
+    PosterSizeEnumeration(String v, int w, int h) {
         value = v;
+        width = w;
+        height = h;
     }
 
     public String value() {
         return value;
+    }
+
+    public int height() {
+        return height;
+    }
+
+    public int width() {
+        return width;
+    }
+
+    public static Map<String, Integer> toSizeMap(PosterSizeEnumeration size) {
+        if (size == null) {
+            return Collections.emptyMap();
+        }
+
+        return Map.of(WIDTH, size.width, HEIGHT, size.height);
     }
 
     public static PosterSizeEnumeration fromValue(String v) {
@@ -24,5 +57,15 @@ public enum PosterSizeEnumeration {
         }
 
         throw new IllegalArgumentException(v + " is not a valid value of PosterSizeEnumeration");
+    }
+
+    public static PosterSizeEnumeration fromSize(Integer w, Integer h) {
+        for (PosterSizeEnumeration c : PosterSizeEnumeration.values()) {
+            if (Objects.equals(c.width, w) && Objects.equals(c.height, h)) {
+                return c;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/main/java/org/rutebanken/tiamat/rest/graphql/GraphQLNames.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/graphql/GraphQLNames.java
@@ -575,6 +575,8 @@ public class GraphQLNames {
 
     public static final String INFO_SPOT_TYPE = "infoSpotType";
     public static final String PURPOSE = "purpose";
+    public static final String WIDTH = "width";
+    public static final String HEIGHT = "height";
     public static final String POSTER_PLACE_SIZE = "posterPlaceSize";
     public static final String BACKLIGHT = "backlight";
     public static final String MAINTENANCE = "maintenance";

--- a/src/main/java/org/rutebanken/tiamat/rest/graphql/fetchers/InfoSpotsUpdater.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/graphql/fetchers/InfoSpotsUpdater.java
@@ -37,6 +37,7 @@ import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.DESCRIPTION;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.DISPLAY_TYPE;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.FLOOR;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.GEOMETRY;
+import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.HEIGHT;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.ID;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.INFO_SPOT_LOCATIONS;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.INFO_SPOT_TYPE;
@@ -50,6 +51,7 @@ import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.POSTER_SIZE;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.PURPOSE;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.RAIL_INFORMATION;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.SPEECH_PROPERTY;
+import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.WIDTH;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.ZONE_LABEL;
 import static org.rutebanken.tiamat.rest.graphql.mappers.EmbeddableMultilingualStringMapper.getEmbeddableString;
 
@@ -151,11 +153,14 @@ public class InfoSpotsUpdater implements DataFetcher {
             isUpdated |= !Objects.equals(description, target.getDescription());
             target.setDescription(getEmbeddableString(description));
         }
+
         if (input.containsKey(POSTER_PLACE_SIZE)) {
             var posterPlaceSize = (PosterSizeEnumeration) input.get(POSTER_PLACE_SIZE);
-            isUpdated |= !Objects.equals(posterPlaceSize, target.getPosterPlaceSize());
-            target.setPosterPlaceSize(posterPlaceSize);
+            isUpdated |= populateInfoSpotSize(PosterSizeEnumeration.toSizeMap(posterPlaceSize), target);
+        } else {
+            isUpdated |= populateInfoSpotSize(input, target);
         }
+
         if (input.containsKey(BACKLIGHT)) {
             var backlight = (Boolean) input.get(BACKLIGHT);
             isUpdated |= !Objects.equals(backlight, target.getBacklight());
@@ -228,6 +233,22 @@ public class InfoSpotsUpdater implements DataFetcher {
         return isUpdated;
     }
 
+    private boolean populateInfoSpotSize(Map input, InfoSpot target) {
+        boolean isUpdated = false;
+
+        if (input.containsKey(WIDTH) && !Objects.equals(target.getWidth(), input.get(WIDTH))) {
+            target.setWidth((Integer) input.get(WIDTH));
+            isUpdated = true;
+        }
+
+        if (input.containsKey(HEIGHT) && !Objects.equals(target.getHeight(), input.get(HEIGHT))) {
+            target.setHeight((Integer) input.get(HEIGHT));
+            isUpdated = true;
+        }
+
+        return isUpdated;
+    }
+
     private InfoSpotPoster createPoster(Map input, Set<InfoSpotPoster> existingPosters) {
         if (input.containsKey(LABEL)) {
             boolean isUpdated = false;
@@ -249,8 +270,20 @@ public class InfoSpotsUpdater implements DataFetcher {
                 isUpdated = true;
             }
 
-            if (input.containsKey(POSTER_SIZE) && !Objects.equals(poster.getPosterSize(), input.get(POSTER_SIZE))) {
-                poster.setPosterSize((PosterSizeEnumeration) input.get(POSTER_SIZE));
+            if (input.containsKey(POSTER_SIZE)) {
+                var posterSize = (PosterSizeEnumeration) input.get(POSTER_SIZE);
+                isUpdated |= populatePosterSize(PosterSizeEnumeration.toSizeMap(posterSize), poster);
+            } else {
+                isUpdated |= populatePosterSize(input, poster);
+            }
+
+            if (input.containsKey(WIDTH) && !Objects.equals(poster.getWidth(), input.get(WIDTH))) {
+                poster.setWidth((Integer) input.get(WIDTH));
+                isUpdated = true;
+            }
+
+            if (input.containsKey(HEIGHT) && !Objects.equals(poster.getHeight(), input.get(HEIGHT))) {
+                poster.setHeight((Integer) input.get(HEIGHT));
                 isUpdated = true;
             }
 
@@ -262,5 +295,21 @@ public class InfoSpotsUpdater implements DataFetcher {
         else {
             throw new IllegalArgumentException("Expected label for poster, none provided");
         }
+    }
+
+    private boolean populatePosterSize(Map input, InfoSpotPoster target) {
+        boolean isUpdated = false;
+
+        if (input.containsKey(WIDTH) && !Objects.equals(target.getWidth(), input.get(WIDTH))) {
+            target.setWidth((Integer) input.get(WIDTH));
+            isUpdated = true;
+        }
+
+        if (input.containsKey(HEIGHT) && !Objects.equals(target.getHeight(), input.get(HEIGHT))) {
+            target.setHeight((Integer) input.get(HEIGHT));
+            isUpdated = true;
+        }
+
+        return isUpdated;
     }
 }

--- a/src/main/java/org/rutebanken/tiamat/rest/graphql/types/InfoSpotObjectTypeCreator.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/graphql/types/InfoSpotObjectTypeCreator.java
@@ -2,7 +2,6 @@ package org.rutebanken.tiamat.rest.graphql.types;
 
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLInputObjectType;
-import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLObjectType;
 import org.rutebanken.tiamat.model.DisplayTypeEnumeration;
@@ -11,6 +10,7 @@ import org.rutebanken.tiamat.model.PosterSizeEnumeration;
 import org.springframework.stereotype.Component;
 
 import static graphql.Scalars.GraphQLBoolean;
+import static graphql.Scalars.GraphQLInt;
 import static graphql.Scalars.GraphQLString;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLInputObjectField.newInputObjectField;
@@ -21,8 +21,8 @@ import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.DESCRIPTION;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.DISPLAY_TYPE;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.FLOOR;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.GEOMETRY;
+import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.HEIGHT;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.ID;
-import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.INFO_SPOTS;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.INFO_SPOT_LOCATIONS;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.INFO_SPOT_TYPE;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.INPUT_TYPE_INFO_SPOT;
@@ -39,6 +39,7 @@ import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.RAIL_INFORMATION;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.SPEECH_PROPERTY;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.VALID_BETWEEN;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.VERSION;
+import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.WIDTH;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.ZONE_LABEL;
 import static org.rutebanken.tiamat.rest.graphql.types.CustomGraphQLTypes.createCustomEnumType;
 import static org.rutebanken.tiamat.rest.graphql.types.CustomGraphQLTypes.embeddableMultiLingualStringInputObjectType;
@@ -50,7 +51,6 @@ import static org.rutebanken.tiamat.rest.graphql.types.CustomGraphQLTypes.netexI
 
 @Component
 public class InfoSpotObjectTypeCreator {
-
     public static GraphQLEnumType infoSpotTypeEnum = createCustomEnumType(INFO_SPOT_TYPE, InfoSpotTypeEnumeration.class);
     public static GraphQLEnumType posterSizeEnum = createCustomEnumType(POSTER_PLACE_SIZE, PosterSizeEnumeration.class);
     public static GraphQLEnumType displayTypeEnum = createCustomEnumType(DISPLAY_TYPE, DisplayTypeEnumeration.class);
@@ -69,6 +69,12 @@ public class InfoSpotObjectTypeCreator {
                             .name(POSTER_SIZE)
                             .type(posterSizeEnum))
                     .field(newFieldDefinition()
+                            .name(WIDTH)
+                            .type(GraphQLInt))
+                    .field(newFieldDefinition()
+                            .name(HEIGHT)
+                            .type(GraphQLInt))
+                    .field(newFieldDefinition()
                             .name(LINES)
                             .type(GraphQLString))
                     .build();
@@ -82,6 +88,12 @@ public class InfoSpotObjectTypeCreator {
                     .field(newInputObjectField()
                             .name(POSTER_SIZE)
                             .type(posterSizeEnum))
+                    .field(newInputObjectField()
+                            .name(WIDTH)
+                            .type(GraphQLInt))
+                    .field(newInputObjectField()
+                            .name(HEIGHT)
+                            .type(GraphQLInt))
                     .field(newInputObjectField()
                             .name(LINES)
                             .type(GraphQLString))
@@ -110,6 +122,12 @@ public class InfoSpotObjectTypeCreator {
                 .field(newFieldDefinition()
                         .name(POSTER_PLACE_SIZE)
                         .type(posterSizeEnum))
+                .field(newFieldDefinition()
+                        .name(WIDTH)
+                        .type(GraphQLInt))
+                .field(newFieldDefinition()
+                        .name(HEIGHT)
+                        .type(GraphQLInt))
                 .field(newFieldDefinition()
                         .name(DESCRIPTION)
                         .type(embeddableMultilingualStringObjectType))
@@ -164,6 +182,12 @@ public class InfoSpotObjectTypeCreator {
                 .field(newInputObjectField()
                         .name(POSTER_PLACE_SIZE)
                         .type(posterSizeEnum))
+                .field(newInputObjectField()
+                        .name(WIDTH)
+                        .type(GraphQLInt))
+                .field(newInputObjectField()
+                        .name(HEIGHT)
+                        .type(GraphQLInt))
                 .field(newInputObjectField()
                         .name(DESCRIPTION)
                         .type(embeddableMultiLingualStringInputObjectType))

--- a/src/main/resources/db/migration/V47.5__info_spot_and_poster_size.sql
+++ b/src/main/resources/db/migration/V47.5__info_spot_and_poster_size.sql
@@ -1,0 +1,22 @@
+-- Update info spot
+ALTER TABLE info_spot
+    ADD COLUMN width INTEGER,
+    ADD COLUMN height INTEGER;
+
+UPDATE info_spot SET width = 297, height = 420  WHERE poster_place_size = 'a3';
+UPDATE info_spot SET width = 210, height = 297  WHERE poster_place_size = 'a4';
+UPDATE info_spot SET width = 800, height = 1200 WHERE poster_place_size = 'cm80x120';
+
+ALTER TABLE info_spot DROP COLUMN poster_place_size;
+
+
+-- Alter info spot poster
+ALTER TABLE info_spot_poster
+    ADD COLUMN width INTEGER,
+    ADD COLUMN height INTEGER;
+
+UPDATE info_spot_poster SET width = 297, height = 420  WHERE poster_size = 'a3';
+UPDATE info_spot_poster SET width = 210, height = 297  WHERE poster_size = 'a4';
+UPDATE info_spot_poster SET width = 800, height = 1200 WHERE poster_size = 'cm80x120';
+
+ALTER TABLE info_spot_poster DROP COLUMN poster_size;

--- a/src/test/java/org/rutebanken/tiamat/rest/graphql/GraphQLResourceInfoSpotIntegrationTest.java
+++ b/src/test/java/org/rutebanken/tiamat/rest/graphql/GraphQLResourceInfoSpotIntegrationTest.java
@@ -24,6 +24,10 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
 
     private final GeometryFactory geometryFactory = new GeometryFactoryConfig().geometryFactory();
 
+    private static final Size SIZE_A3 = new Size(297, 420);
+    private static final Size SIZE_A4 = new Size(210, 297);
+    private static final Size SIZE_80_120 = new Size(800, 1200);
+
     static String INFO_SPOT_ID = "NSR:InfoSpot:1";
     static String INFO_SPOT2_ID = "NSR:InfoSpot:2";
 
@@ -55,6 +59,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                     }
                     maintenance
                     posterPlaceSize
+                    width
+                    height
                     purpose
                     railInformation
                     zoneLabel
@@ -67,6 +73,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                     poster {
                         label
                         posterSize
+                        width
+                        height
                         lines
                     }
                 }
@@ -84,7 +92,10 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                 .body("floor", equalTo(updatedInfoSpot.getFloor()))
                 .body("description.value", equalTo(updatedInfoSpot.getDescription().getValue()))
                 .body("maintenance", equalTo(updatedInfoSpot.getMaintenance()))
+                // Deprecated field, test compatability
                 .body("posterPlaceSize", equalTo(updatedInfoSpot.getPosterPlaceSize().value()))
+                .body("width", equalTo(updatedInfoSpot.getWidth()))
+                .body("height", equalTo(updatedInfoSpot.getHeight()))
                 .body("purpose", equalTo(updatedInfoSpot.getPurpose()))
                 .body("railInformation", equalTo(updatedInfoSpot.getRailInformation()))
                 .body("zoneLabel", equalTo(updatedInfoSpot.getZoneLabel()))
@@ -94,7 +105,10 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                 .body("geometry.coordinates[1]", equalTo((float)updatedInfoSpot.getCentroid().getY()))
                 .appendRootPath("poster[0]")
                 .body("label", equalTo(updatedPoster.getLabel()))
+                // Deprecated field, test compatability
                 .body("posterSize", equalTo(updatedPoster.getPosterSize().value()))
+                .body("width", equalTo(updatedPoster.getWidth()))
+                .body("height", equalTo(updatedPoster.getHeight()))
                 .body("lines", equalTo(updatedPoster.getLines()))
                 .rootPath("data.infoSpots[1]")
                 .body("id", equalTo(otherInfoSpot.getNetexId()))
@@ -105,7 +119,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                 .body("floor", equalTo(otherInfoSpot.getFloor()))
                 .body("description.value", equalTo(otherInfoSpot.getDescription().getValue()))
                 .body("maintenance", equalTo(otherInfoSpot.getMaintenance()))
-                .body("posterPlaceSize", equalTo(otherInfoSpot.getPosterPlaceSize().value()))
+                .body("width", equalTo(otherInfoSpot.getWidth()))
+                .body("height", equalTo(otherInfoSpot.getHeight()))
                 .body("purpose", equalTo(otherInfoSpot.getPurpose()))
                 .body("railInformation", equalTo(otherInfoSpot.getRailInformation()))
                 .body("zoneLabel", equalTo(otherInfoSpot.getZoneLabel()))
@@ -115,7 +130,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                 .body("geometry.coordinates[1]", equalTo((float)otherInfoSpot.getCentroid().getY()))
                 .appendRootPath("poster[0]")
                 .body("label", equalTo(otherPoster.getLabel()))
-                .body("posterSize", equalTo(otherPoster.getPosterSize().value()))
+                .body("width", equalTo(otherPoster.getWidth()))
+                .body("height", equalTo(otherPoster.getHeight()))
                 .body("lines", equalTo(otherPoster.getLines()));
     }
 
@@ -138,7 +154,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                         lang
                     }
                     maintenance
-                    posterPlaceSize
+                    width
+                    height
                     purpose
                     railInformation
                     zoneLabel
@@ -150,7 +167,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                     }
                     poster {
                         label
-                        posterSize
+                        width
+                        height
                         lines
                     }
                 }
@@ -168,7 +186,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                 .body("floor", equalTo(updatedInfoSpot.getFloor()))
                 .body("description.value", equalTo(updatedInfoSpot.getDescription().getValue()))
                 .body("maintenance", equalTo(updatedInfoSpot.getMaintenance()))
-                .body("posterPlaceSize", equalTo(updatedInfoSpot.getPosterPlaceSize().value()))
+                .body("width", equalTo(updatedInfoSpot.getWidth()))
+                .body("height", equalTo(updatedInfoSpot.getHeight()))
                 .body("purpose", equalTo(updatedInfoSpot.getPurpose()))
                 .body("railInformation", equalTo(updatedInfoSpot.getRailInformation()))
                 .body("zoneLabel", equalTo(updatedInfoSpot.getZoneLabel()))
@@ -178,7 +197,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                 .body("geometry.coordinates[1]", equalTo((float)updatedInfoSpot.getCentroid().getY()))
                 .appendRootPath("poster[0]")
                 .body("label", equalTo(updatedPoster.getLabel()))
-                .body("posterSize", equalTo(updatedPoster.getPosterSize().value()))
+                .body("width", equalTo(updatedPoster.getWidth()))
+                .body("height", equalTo(updatedPoster.getHeight()))
                 .body("lines", equalTo(updatedPoster.getLines()));
     }
 
@@ -190,7 +210,7 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
         String floor = "2";
         String description = "Description of info spot";
         String maintenance = "Maintainer";
-        PosterSizeEnumeration size = PosterSizeEnumeration.CM80x120;
+        Size size = SIZE_80_120;
         String purpose = "Purpose of info";
         String railInformation = "Rail 1";
         String zoneLabel = "A";
@@ -199,7 +219,7 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
         String location2 = "NSH:StopPlace:2";
 
         String posterLabel = "Info Poster";
-        PosterSizeEnumeration posterSize = PosterSizeEnumeration.A3;
+        Size posterSize = SIZE_A3;
         String posterLines = "1, 4, 5";
         Float lat = 60.0F;
         Float lon = 50.0F;
@@ -216,7 +236,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                             value: "%s"
                         }
                         maintenance: "%s"
-                        posterPlaceSize: %s
+                        width: %s
+                        height: %s
                         purpose: "%s"
                         railInformation: "%s"
                         zoneLabel: "%s"
@@ -232,7 +253,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                         poster: [
                             {
                                 label: "%s",
-                                posterSize: %s,
+                                width: %s,
+                                height: %s,
                                 lines: "%s"
                             }
                         ]
@@ -249,7 +271,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                         lang
                     }
                     maintenance
-                    posterPlaceSize
+                    width
+                    height
                     purpose
                     railInformation
                     zoneLabel
@@ -261,7 +284,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                     }
                     poster {
                         label
-                        posterSize
+                        width
+                        height
                         lines
                     }
                 }
@@ -273,7 +297,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
             floor,
             description,
             maintenance,
-            size.value(),
+            size.width(),
+            size.height(),
             purpose,
             railInformation,
             zoneLabel,
@@ -283,7 +308,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
             lat.toString(),
             lon.toString(),
             posterLabel,
-            posterSize.value(),
+            posterSize.width(),
+            posterSize.height(),
             posterLines
         );
 
@@ -296,7 +322,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                 .body("floor", equalTo(floor))
                 .body("description.value", equalTo(description))
                 .body("maintenance", equalTo(maintenance))
-                .body("posterPlaceSize", equalTo(size.value()))
+                .body("width", equalTo(size.width()))
+                .body("height", equalTo(size.height()))
                 .body("purpose", equalTo(purpose))
                 .body("railInformation", equalTo(railInformation))
                 .body("zoneLabel", equalTo(zoneLabel))
@@ -306,7 +333,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                 .body("geometry.coordinates[1]", equalTo(lon))
                 .appendRootPath("poster[0]")
                 .body("label", equalTo(posterLabel))
-                .body("posterSize", equalTo(posterSize.value()))
+                .body("width", equalTo(posterSize.width()))
+                .body("height", equalTo(posterSize.height()))
                 .body("lines", equalTo(posterLines));
     }
 
@@ -320,7 +348,7 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
         String floor = "2";
         String description = "Descriptive";
         String maintenance = "Maintainer";
-        PosterSizeEnumeration size = PosterSizeEnumeration.CM80x120;
+        Size size = SIZE_80_120;
         String purpose = "Purpose of info";
         String railInformation = "Rail 1";
         String zoneLabel = "A";
@@ -331,7 +359,7 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
         float lon = 52.0F;
 
         String posterLabel = ("Informative poster");
-        PosterSizeEnumeration posterSize = PosterSizeEnumeration.A4;
+        Size posterSize = SIZE_A4;
         String posterLines = "1, 2, 5";
 
 
@@ -345,7 +373,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                             value: "%s"
                         }
                         maintenance: "%s"
-                        posterPlaceSize: %s
+                        width: %s
+                        height: %s
                         purpose: "%s"
                         railInformation: "%s"
                         zoneLabel: "%s"
@@ -361,7 +390,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                         poster: [
                             {
                                 label: "%s",
-                                posterSize: %s,
+                                width: %s,
+                                height: %s,
                                 lines: "%s"
                             }
                         ]
@@ -378,7 +408,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                         lang
                     }
                     maintenance
-                    posterPlaceSize
+                    width
+                    height
                     purpose
                     railInformation
                     zoneLabel
@@ -390,7 +421,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                     }
                     poster {
                         label
-                        posterSize
+                        width
+                        height
                         lines
                     }
                 }
@@ -400,7 +432,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
             floor,
             description,
             maintenance,
-            size.value(),
+            size.width(),
+            size.height(),
             purpose,
             railInformation,
             zoneLabel,
@@ -410,7 +443,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
             lat,
             lon,
             posterLabel,
-            posterSize.value(),
+            posterSize.width(),
+            posterSize.height(),
             posterLines
         );
 
@@ -424,7 +458,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                 .body("floor", equalTo(floor))
                 .body("description.value", equalTo(description))
                 .body("maintenance", equalTo(maintenance))
-                .body("posterPlaceSize", equalTo(size.value()))
+                .body("width", equalTo(size.width()))
+                .body("height", equalTo(size.height()))
                 .body("purpose", equalTo(purpose))
                 .body("railInformation", equalTo(railInformation))
                 .body("zoneLabel", equalTo(zoneLabel))
@@ -435,7 +470,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                 .body("poster", hasSize(1))
                 .appendRootPath("poster[0]")
                 .body("label", equalTo(posterLabel))
-                .body("posterSize", equalTo(posterSize.value()))
+                .body("width", equalTo(posterSize.width()))
+                .body("height", equalTo(posterSize.height()))
                 .body("lines", equalTo(posterLines));
 
 
@@ -454,7 +490,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                         lang
                     }
                     maintenance
-                    posterPlaceSize
+                    width
+                    height
                     purpose
                     railInformation
                     zoneLabel
@@ -466,7 +503,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                     }
                     poster {
                         label
-                        posterSize
+                        width
+                        height
                         lines
                     }
                 }
@@ -483,7 +521,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                 .body("floor", equalTo(floor))
                 .body("description.value", equalTo(description))
                 .body("maintenance", equalTo(maintenance))
-                .body("posterPlaceSize", equalTo(size.value()))
+                .body("width", equalTo(size.width()))
+                .body("height", equalTo(size.height()))
                 .body("purpose", equalTo(purpose))
                 .body("railInformation", equalTo(railInformation))
                 .body("zoneLabel", equalTo(zoneLabel))
@@ -494,8 +533,62 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                 .body("poster", hasSize(1))
                 .appendRootPath("poster[0]")
                 .body("label", equalTo(posterLabel))
-                .body("posterSize", equalTo(posterSize.value()))
+                .body("width", equalTo(posterSize.width()))
+                .body("height", equalTo(posterSize.height()))
                 .body("lines", equalTo(posterLines));
+    }
+
+    @Test
+    public void updateInfoSpotByOldEnumApi() {
+        insertInfoSpots();
+
+        long version = otherInfoSpot.getVersion() + 1;
+        String netexId = INFO_SPOT2_ID;
+        String posterLabel = ("Informative poster");
+
+        String graphQlJsonMutation = """
+                mutation {
+                    infoSpot: mutateInfoSpots(
+                        infoSpot: {
+                            id: "%s"
+                            posterPlaceSize: %s
+                            poster: [
+                                {
+                                    label: "%s"
+                                    posterSize: %s
+                                }
+                            ]
+                        }
+                    ) {
+                        id
+                        posterPlaceSize
+                        width
+                        height
+                        poster {
+                            posterSize
+                            width
+                            height
+                        }
+                    }
+                }
+                """.formatted(
+                netexId,
+                PosterSizeEnumeration.A3.value(),
+                posterLabel,
+                PosterSizeEnumeration.A3.value()
+        );
+
+        executeGraphqQLQueryOnly(graphQlJsonMutation)
+                .rootPath("data.infoSpot[0]")
+                .body("id", equalTo(netexId))
+                .body("width", equalTo(PosterSizeEnumeration.A3.width()))
+                .body("height", equalTo(PosterSizeEnumeration.A3.height()))
+                .body("posterPlaceSize", equalTo(PosterSizeEnumeration.A3.value()))
+                .body("poster", hasSize(1))
+                .appendRootPath("poster[0]")
+                .body("width", equalTo(PosterSizeEnumeration.A3.width()))
+                .body("height", equalTo(PosterSizeEnumeration.A3.height()))
+                .body("posterSize", equalTo(PosterSizeEnumeration.A3.value()));
     }
 
     @Test
@@ -514,7 +607,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
         infoSpot.setFloor("2");
         infoSpot.setDescription(new EmbeddableMultilingualString("Descriptive"));
         infoSpot.setMaintenance("Maintainer");
-        infoSpot.setPosterPlaceSize(PosterSizeEnumeration.CM80x120);
+        infoSpot.setWidth(SIZE_80_120.width());
+        infoSpot.setHeight(SIZE_80_120.height());
         infoSpot.setPurpose("Purpose of info");
         infoSpot.setRailInformation("Rail 1");
         infoSpot.setZoneLabel("A");
@@ -569,7 +663,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
         infoSpot.setFloor("2");
         infoSpot.setDescription(new EmbeddableMultilingualString("Descriptive"));
         infoSpot.setMaintenance("Maintainer");
-        infoSpot.setPosterPlaceSize(PosterSizeEnumeration.CM80x120);
+        infoSpot.setWidth(SIZE_80_120.width());
+        infoSpot.setHeight(SIZE_80_120.height());
         infoSpot.setPurpose("Purpose of info");
         infoSpot.setRailInformation("Rail 1");
         infoSpot.setZoneLabel("A");
@@ -625,7 +720,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                             poster: [
                                 {
                                     label: "%s",
-                                    posterSize: %s,
+                                    width: %s,
+                                    height: %s,
                                     lines: "%s"
                                 }
                             ]
@@ -635,7 +731,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                         poster {
                             version
                             label
-                            posterSize
+                            width
+                            height
                             lines
                         }
                     }
@@ -643,7 +740,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                 """.formatted(
                 updatedInfoSpot.getNetexId(),
                 updatedPoster.getLabel(),
-                updatedPoster.getPosterSize().value(),
+                updatedPoster.getWidth(),
+                updatedPoster.getHeight(),
                 newLines
         );
 
@@ -654,7 +752,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
                 .appendRootPath("poster[0]")
                 .body("version", equalTo(Long.toString(updatedPoster.getVersion() + 1)))
                 .body("label", equalTo(updatedPoster.getLabel()))
-                .body("posterSize", equalTo(updatedPoster.getPosterSize().value()))
+                .body("width", equalTo(updatedPoster.getWidth()))
+                .body("height", equalTo(updatedPoster.getHeight()))
                 .body("lines", equalTo(newLines));
     }
 
@@ -672,7 +771,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
         oldInfoSpot.setFloor("2");
         oldInfoSpot.setDescription(new EmbeddableMultilingualString("Descriptive"));
         oldInfoSpot.setMaintenance("Maintainer");
-        oldInfoSpot.setPosterPlaceSize(PosterSizeEnumeration.CM80x120);
+        oldInfoSpot.setWidth(SIZE_80_120.width());
+        oldInfoSpot.setHeight(SIZE_80_120.height());
         oldInfoSpot.setPurpose("Purpose of info");
         oldInfoSpot.setRailInformation("Rail 1");
         oldInfoSpot.setZoneLabel("A");
@@ -684,7 +784,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
         oldPoster.setNetexId("NSR:InfoSpotPoster:1");
         oldPoster.setVersion(1);
         oldPoster.setLabel("Informative poster");
-        oldPoster.setPosterSize(PosterSizeEnumeration.A4);
+        oldPoster.setWidth(SIZE_A4.width());
+        oldPoster.setHeight(SIZE_A4.height());
         oldPoster.setLines("1, 2, 5");
 
         infoSpotPosterRepository.save(oldPoster);
@@ -709,7 +810,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
         updatedInfoSpot.setFloor("3");
         updatedInfoSpot.setDescription(new EmbeddableMultilingualString("New Description"));
         updatedInfoSpot.setMaintenance("New Maintainer");
-        updatedInfoSpot.setPosterPlaceSize(PosterSizeEnumeration.A3);
+        updatedInfoSpot.setWidth(SIZE_A3.width());
+        updatedInfoSpot.setHeight(SIZE_A3.height());
         updatedInfoSpot.setPurpose("New purpose of info");
         updatedInfoSpot.setRailInformation("Rail 2");
         updatedInfoSpot.setZoneLabel("B");
@@ -721,7 +823,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
         updatedPoster.setNetexId("NSR:InfoSpotPoster:1");
         updatedPoster.setVersion(2);
         updatedPoster.setLabel("More informative poster");
-        updatedPoster.setPosterSize(PosterSizeEnumeration.A3);
+        updatedPoster.setWidth(SIZE_A3.width());
+        updatedPoster.setHeight(SIZE_A3.height());
         updatedPoster.setLines("3, 4");
 
         infoSpotPosterRepository.save(updatedPoster);
@@ -746,7 +849,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
         otherInfoSpot.setFloor("3");
         otherInfoSpot.setDescription(new EmbeddableMultilingualString("Other description"));
         otherInfoSpot.setMaintenance("Maintainer three");
-        otherInfoSpot.setPosterPlaceSize(PosterSizeEnumeration.A4);
+        otherInfoSpot.setWidth(SIZE_A4.width());
+        otherInfoSpot.setHeight(SIZE_A4.height());
         otherInfoSpot.setPurpose("Other purpose");
         otherInfoSpot.setRailInformation("Rail 3");
         otherInfoSpot.setZoneLabel("C");
@@ -758,7 +862,8 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
         otherPoster.setNetexId("NSR:InfoSpotPoster:2");
         otherPoster.setVersion(1);
         otherPoster.setLabel("Other poster");
-        otherPoster.setPosterSize(PosterSizeEnumeration.A4);
+        otherPoster.setWidth(SIZE_A4.width());
+        otherPoster.setHeight(SIZE_A4.height());
         otherPoster.setLines("7");
 
         infoSpotPosterRepository.save(otherPoster);
@@ -769,4 +874,6 @@ public class GraphQLResourceInfoSpotIntegrationTest extends AbstractGraphQLResou
 
         infoSpotRepository.save(otherInfoSpot);
     }
+
+    private record Size(Integer width, Integer height) {}
 }


### PR DESCRIPTION
* Deprecated the PosterSizeEnum
  - Class extended with size info
  - ~GraphQL API bits marked deprecated~ (Hasura drops these fields on input types)
  - Added compatibility code to InfoSpotsUpdater to convert old enum API calls to the new format.
  - Still needed because we can't commit the UI code changes together with tiamat.
* Added new DB fields `width` and `height` to the `info_spot` and `info_spot_poster` tables. Data store is integer millimeters.
* Removed the old `poster_place_size` and `poster_size` columns.
* Migrated the old rows to the new format based on the existing enum column value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-tiamat/91)
<!-- Reviewable:end -->
