### PR TITLE
Add more fields to the create new terminal mutation

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/rest/graphql/StopPlaceRegisterGraphQLSchema.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/graphql/StopPlaceRegisterGraphQLSchema.java
@@ -37,6 +37,7 @@ import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
 import org.rutebanken.tiamat.model.AccessibilityAssessment;
 import org.rutebanken.tiamat.model.AccessibilityLimitation;
+import org.rutebanken.tiamat.model.AlternativeName;
 import org.rutebanken.tiamat.model.CycleStorageEquipment;
 import org.rutebanken.tiamat.model.DataManagedObjectStructure;
 import org.rutebanken.tiamat.model.EmbeddableMultilingualString;
@@ -47,6 +48,7 @@ import org.rutebanken.tiamat.model.GroupOfTariffZones;
 import org.rutebanken.tiamat.model.InfoSpot;
 import org.rutebanken.tiamat.model.Link;
 import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.PrivateCodeStructure;
 import org.rutebanken.tiamat.model.PurposeOfGrouping;
 import org.rutebanken.tiamat.model.Quay;
 import org.rutebanken.tiamat.model.SanitaryEquipment;
@@ -57,6 +59,7 @@ import org.rutebanken.tiamat.model.TariffZone;
 import org.rutebanken.tiamat.model.TicketingEquipment;
 import org.rutebanken.tiamat.model.TopographicPlace;
 import org.rutebanken.tiamat.model.ValidBetween;
+import org.rutebanken.tiamat.model.Value;
 import org.rutebanken.tiamat.model.WaitingRoomEquipment;
 import org.rutebanken.tiamat.model.Zone_VersionStructure;
 import org.rutebanken.tiamat.model.identification.IdentifiedEntity;
@@ -73,7 +76,10 @@ import org.rutebanken.tiamat.rest.graphql.fetchers.StopPlaceFareZoneFetcher;
 import org.rutebanken.tiamat.rest.graphql.fetchers.StopPlaceTariffZoneFetcher;
 import org.rutebanken.tiamat.rest.graphql.fetchers.TagFetcher;
 import org.rutebanken.tiamat.rest.graphql.fetchers.UserPermissionsFetcher;
+import org.rutebanken.tiamat.rest.graphql.mappers.AlternativeNameMapper;
 import org.rutebanken.tiamat.rest.graphql.mappers.GeometryMapper;
+import org.rutebanken.tiamat.rest.graphql.mappers.KeyValueMapper;
+import org.rutebanken.tiamat.rest.graphql.mappers.PrivateCodeMapper;
 import org.rutebanken.tiamat.rest.graphql.mappers.ValidBetweenMapper;
 import org.rutebanken.tiamat.rest.graphql.operations.MultiModalityOperationsBuilder;
 import org.rutebanken.tiamat.rest.graphql.operations.OrganisationOperationsBuilder;
@@ -355,6 +361,9 @@ public class StopPlaceRegisterGraphQLSchema {
 
     @Autowired
     private GeometryMapper geometryMapper;
+
+    @Autowired
+    private AlternativeNameMapper alternativeNameMapper;
 
     @Autowired
     private MultiModalStopPlaceEditor parentStopPlaceEditor;
@@ -993,11 +1002,16 @@ public class StopPlaceRegisterGraphQLSchema {
                     String versionComment = (String) input.get(VERSION_COMMENT);
                     Point geoJsonPoint = geometryMapper.createGeoJsonPoint((Map) input.get(GEOMETRY));
                     EmbeddableMultilingualString name = getEmbeddableString((Map) input.get(NAME));
+                    PrivateCodeStructure privateCode = PrivateCodeMapper.getPrivateCodeStructure((Map) input.get(PRIVATE_CODE));
+                    Map<String, Value> keyValues = KeyValueMapper.getKeyValuesMap((List) input.get(KEY_VALUES));
+                    List<AlternativeName> alternativeNames = input.get(ALTERNATIVE_NAMES) != null
+                            ? alternativeNameMapper.mapAlternativeNames((List) input.get(ALTERNATIVE_NAMES))
+                            : null;
 
                     @SuppressWarnings("unchecked")
                     List<String> stopPlaceIds = (List<String>) input.get(STOP_PLACE_IDS);
 
-                    return parentStopPlaceEditor.createMultiModalParentStopPlace(stopPlaceIds, name, validBetween, versionComment, geoJsonPoint);
+                    return parentStopPlaceEditor.createMultiModalParentStopPlace(stopPlaceIds, name, validBetween, versionComment, geoJsonPoint, privateCode, alternativeNames, keyValues);
                 }
                     );
 

--- a/src/main/java/org/rutebanken/tiamat/rest/graphql/mappers/KeyValueMapper.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/graphql/mappers/KeyValueMapper.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.tiamat.rest.graphql.mappers;
+
+import org.rutebanken.tiamat.model.Value;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class KeyValueMapper {
+    public static Map<String, Value> getKeyValuesMap(List<Map<String, Object>> keyValuesInput) {
+        if (keyValuesInput == null) {
+            return null;
+        }
+
+        Map<String, Value> keyValues = new HashMap<>();
+
+        if (keyValuesInput != null) {
+            keyValuesInput.forEach(kvInput -> {
+                var key = (String) kvInput.get("key");
+
+                if (key != null && !key.isBlank()) {
+                    var values = kvInput.get("values");
+
+                    if (values != null) {
+                        keyValues.put(key, new Value((List<String>) values));
+                    } else {
+                        keyValues.put(key, null);
+                    }
+                }
+            });
+        }
+
+        return keyValues;
+    }
+}

--- a/src/main/java/org/rutebanken/tiamat/rest/graphql/operations/MultiModalityOperationsBuilder.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/graphql/operations/MultiModalityOperationsBuilder.java
@@ -32,18 +32,26 @@ import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLInputObjectField.newInputObjectField;
 import static graphql.schema.GraphQLInputObjectType.newInputObject;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.ADD_TO_MULTIMODAL_STOPPLACE;
+import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.ALTERNATIVE_NAMES;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.CREATE_MULTI_MODAL_STOPPLACE;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.DESCRIPTION;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.GEOMETRY;
+import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.KEY_VALUES;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.NAME;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.PARENT_SITE_REF;
+import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.PRIVATE_CODE;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.REMOVE_FROM_MULTIMODAL_STOPPLACE;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.STOP_PLACE_ID;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.STOP_PLACE_IDS;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.VALID_BETWEEN;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.VERSION_COMMENT;
+import static org.rutebanken.tiamat.rest.graphql.types.CustomGraphQLTypes.alternativeNameInputObjectType;
+import static org.rutebanken.tiamat.rest.graphql.types.CustomGraphQLTypes.alternativeNameObjectType;
 import static org.rutebanken.tiamat.rest.graphql.types.CustomGraphQLTypes.embeddableMultiLingualStringInputObjectType;
 import static org.rutebanken.tiamat.rest.graphql.types.CustomGraphQLTypes.geoJsonInputType;
+import static org.rutebanken.tiamat.rest.graphql.types.CustomGraphQLTypes.keyValuesObjectInputType;
+import static org.rutebanken.tiamat.rest.graphql.types.CustomGraphQLTypes.keyValuesObjectType;
+import static org.rutebanken.tiamat.rest.graphql.types.CustomGraphQLTypes.privateCodeInputType;
 
 @Component
 public class MultiModalityOperationsBuilder {
@@ -66,6 +74,9 @@ public class MultiModalityOperationsBuilder {
         createMultiModalStopPlaceFields.add(newInputObjectField().name(GEOMETRY).type(geoJsonInputType).build());
         createMultiModalStopPlaceFields.add(newInputObjectField().name(VALID_BETWEEN).type(validBetweenInputObjectType).build());
         createMultiModalStopPlaceFields.add(newInputObjectField().name(STOP_PLACE_IDS).type(new GraphQLNonNull(new GraphQLList(GraphQLString))).build());
+        createMultiModalStopPlaceFields.add(newInputObjectField().name(PRIVATE_CODE).type(privateCodeInputType).build());
+        createMultiModalStopPlaceFields.add(newInputObjectField().name(ALTERNATIVE_NAMES).type(new GraphQLList(alternativeNameInputObjectType)).build());
+        createMultiModalStopPlaceFields.add(newInputObjectField().name(KEY_VALUES).type(new GraphQLList(keyValuesObjectInputType)).build());
 
         operations.add(newFieldDefinition()
                 .type(parentStopPlaceObjectType)

--- a/src/main/java/org/rutebanken/tiamat/service/stopplace/MultiModalStopPlaceEditor.java
+++ b/src/main/java/org/rutebanken/tiamat/service/stopplace/MultiModalStopPlaceEditor.java
@@ -18,9 +18,12 @@ package org.rutebanken.tiamat.service.stopplace;
 import org.locationtech.jts.geom.Point;
 import org.rutebanken.tiamat.auth.AuthorizationService;
 import org.rutebanken.tiamat.lock.MutateLock;
+import org.rutebanken.tiamat.model.AlternativeName;
 import org.rutebanken.tiamat.model.EmbeddableMultilingualString;
+import org.rutebanken.tiamat.model.PrivateCodeStructure;
 import org.rutebanken.tiamat.model.StopPlace;
 import org.rutebanken.tiamat.model.ValidBetween;
+import org.rutebanken.tiamat.model.Value;
 import org.rutebanken.tiamat.repository.StopPlaceRepository;
 import org.rutebanken.tiamat.versioning.VersionCreator;
 import org.rutebanken.tiamat.versioning.save.StopPlaceVersionedSaverService;
@@ -33,6 +36,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static java.util.stream.Collectors.toList;
@@ -61,10 +65,13 @@ public class MultiModalStopPlaceEditor {
     private VersionCreator versionCreator;
 
     public StopPlace createMultiModalParentStopPlace(List<String> childStopPlaceIds, EmbeddableMultilingualString name) {
-        return createMultiModalParentStopPlace(childStopPlaceIds, name, null, null, null);
+        return createMultiModalParentStopPlace(childStopPlaceIds, name, null, null, null, null, null, null);
     }
 
-    public StopPlace createMultiModalParentStopPlace(List<String> childStopPlaceIds, EmbeddableMultilingualString name, ValidBetween validBetween, String versionComment, Point geoJsonPoint) {
+    public StopPlace createMultiModalParentStopPlace(List<String> childStopPlaceIds, EmbeddableMultilingualString name,
+                                                     ValidBetween validBetween, String versionComment, Point geoJsonPoint,
+                                                     PrivateCodeStructure privateCode, List<AlternativeName> alternativeNames,
+                                                     Map<String, Value> keyValues) {
 
         return mutateLock.executeInLock(() -> {
 
@@ -82,9 +89,18 @@ public class MultiModalStopPlaceEditor {
             logger.info("Creating first version of parent stop place {}", name);
             final StopPlace parentStopPlace = new StopPlace(name);
             parentStopPlace.setParentStopPlace(true);
+            parentStopPlace.setPrivateCode(privateCode);
             parentStopPlace.setValidBetween(validBetween);
             parentStopPlace.setVersionComment(versionComment);
             parentStopPlace.setCentroid(geoJsonPoint);
+
+            if (alternativeNames != null) {
+                parentStopPlace.getAlternativeNames().addAll(alternativeNames);
+            }
+
+            if (keyValues != null) {
+                parentStopPlace.getKeyValues().putAll(keyValues);
+            }
 
             Set<StopPlace> childCopies = validateAndCopyPotentionalChildren(futureChildStopPlaces, parentStopPlace, fromDate);
             parentStopPlace.getChildren().addAll(childCopies);

--- a/src/test/java/org/rutebanken/tiamat/service/stopplace/MultiModalStopPlaceEditorTest.java
+++ b/src/test/java/org/rutebanken/tiamat/service/stopplace/MultiModalStopPlaceEditorTest.java
@@ -146,8 +146,10 @@ public class MultiModalStopPlaceEditorTest extends TiamatIntegrationTest {
 
         String parentStopPlaceName = "Super Duper StopPlace";
         String versionComment = "version comment";
-        StopPlace result = multiModalStopPlaceEditor.createMultiModalParentStopPlace(Arrays.asList(child.getNetexId()),
-                new EmbeddableMultilingualString(parentStopPlaceName), new ValidBetween(futureTime), versionComment, null);
+        StopPlace result = multiModalStopPlaceEditor.createMultiModalParentStopPlace(
+                Arrays.asList(child.getNetexId()),
+                new EmbeddableMultilingualString(parentStopPlaceName),
+                new ValidBetween(futureTime), versionComment, null, null, null, null);
 
         assertThat(result.getValidBetween().getFromDate()).isEqualTo(futureTime);
 


### PR DESCRIPTION
Terminals must be created using the `createMultiModalStopPlace` mutation, which previously lacked privateCode, alternativeNames, and keyValues inputs. I added these to simplify terminal creation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-tiamat/92)
<!-- Reviewable:end -->
