### PR TITLE
Fix moving stop to a stop place that is part of a terminal

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/service/stopplace/StopPlaceQuayMover.java
+++ b/src/main/java/org/rutebanken/tiamat/service/stopplace/StopPlaceQuayMover.java
@@ -196,7 +196,10 @@ public class StopPlaceQuayMover {
         stopPlaceToAddQuaysTo.setVersionComment(toVersionComment);
 
         logger.debug("Saved stop place with copied quays {} and moved quays {} {}", quaysToAdd, quaysToMove, destinationStopPlace);
-        return save(destination, saveDateTime);
+        save(destination, saveDateTime);
+
+        // After saving, get the latest version of the stop place (save only returns the parent if one exists)
+        return stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(destinationStopPlaceId);
     }
 
     private void validateObjectIsValidOnDate(DataManagedObjectStructure objectWithKeyValues, LocalDate date) throws IllegalArgumentException {

--- a/src/test/java/org/rutebanken/tiamat/service/stopplace/StopPlaceQuayMoverTest.java
+++ b/src/test/java/org/rutebanken/tiamat/service/stopplace/StopPlaceQuayMoverTest.java
@@ -121,7 +121,7 @@ public class StopPlaceQuayMoverTest extends TiamatIntegrationTest {
         String toVersionComment = "to comment";
 
         // Act
-        StopPlace actualParentDestinationStopPlace = stopPlaceQuayMover.moveQuays(Arrays.asList(quayToMove.getNetexId()), destinationStopPlace.getNetexId(), tomorrow, fromVersionComment, toVersionComment);
+        destinationStopPlace = stopPlaceQuayMover.moveQuays(Arrays.asList(quayToMove.getNetexId()), destinationStopPlace.getNetexId(), tomorrow, fromVersionComment, toVersionComment);
 
         // Assert source
         parentSourceStopPlace = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(parentSourceStopPlace.getNetexId());
@@ -137,6 +137,8 @@ public class StopPlaceQuayMoverTest extends TiamatIntegrationTest {
         assertThat(sourceQuay.getKeyValues().get("validityEnd").getItems().stream().findFirst().get()).isEqualTo(todayStr);
 
         // Assert destination
+        StopPlace actualParentDestinationStopPlace = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(destinationStopPlace.getParentSiteRef().getRef());
+        
         assertThat(actualParentDestinationStopPlace).isNotNull();
         assertThat(actualParentDestinationStopPlace.getNetexId()).isEqualTo(parentDestinationStopPlace.getNetexId());
         assertThat(actualParentDestinationStopPlace.getChildren()).hasSize(1);


### PR DESCRIPTION
If the destination stop place was part of a terminal, the mutation incorrectly returned terminal details.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-tiamat/102)
<!-- Reviewable:end -->
