### PR TITLE
Fetch info spots with correct version

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/repository/InfoSpotRepositoryCustom.java
+++ b/src/main/java/org/rutebanken/tiamat/repository/InfoSpotRepositoryCustom.java
@@ -6,4 +6,10 @@ import org.rutebanken.tiamat.model.InfoSpot;
 public interface InfoSpotRepositoryCustom extends DataManagedObjectStructureRepository<InfoSpot> {
 
     List<InfoSpot> findForAssociation(String netexId);
+
+    /**
+     * Find InfoSpots associated with a specific version of an entity.
+     * Only returns InfoSpots whose locationRefs match both the netexId AND version.
+     */
+    List<InfoSpot> findForAssociationWithVersion(String netexId, Long version);
 }

--- a/src/main/java/org/rutebanken/tiamat/repository/InfoSpotRepositoryImpl.java
+++ b/src/main/java/org/rutebanken/tiamat/repository/InfoSpotRepositoryImpl.java
@@ -39,4 +39,21 @@ public class InfoSpotRepositoryImpl implements InfoSpotRepositoryCustom {
                 .setParameter("netexId", netexId)
                 .getResultList();
     }
+
+    @Override
+    public List<InfoSpot> findForAssociationWithVersion(String netexId, Long version) {
+        String sql = """
+            SELECT DISTINCT ip.*
+            FROM info_spot ip
+            INNER JOIN info_spot_location isl ON
+                ip.id = isl.info_spot_id AND
+                isl.location_netex_id = :netexId AND
+                (isl.version = CAST(:version AS VARCHAR) OR isl.version IS NULL)
+        """;
+
+        return entityManager.createNativeQuery(sql, InfoSpot.class)
+                .setParameter("netexId", netexId)
+                .setParameter("version", version)
+                .getResultList();
+    }
 }

--- a/src/main/java/org/rutebanken/tiamat/rest/graphql/fetchers/InfoSpotsUpdater.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/graphql/fetchers/InfoSpotsUpdater.java
@@ -6,6 +6,8 @@ import graphql.schema.DataFetchingEnvironment;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -139,14 +141,51 @@ public class InfoSpotsUpdater implements DataFetcher {
         if (isUpdated) {
             authorizationService.assertAuthorized(ROLE_EDIT_STOPS, Arrays.asList(existingVersion, updatedInfoSpot));
 
-            versionIncrementor.initiateOrIncrementInfoSpot(updatedInfoSpot);
+            // Check if this is a deletion
+            boolean isDeletion = (updatedInfoSpot.getLocationRefs() == null || updatedInfoSpot.getLocationRefs().isEmpty()) 
+                && existingVersion != null 
+                && existingVersion.getLocationRefs() != null 
+                && !existingVersion.getLocationRefs().isEmpty();
 
-            logger.info("Saving new version of InfoSpot {}", updatedInfoSpot);
-            updatedInfoSpot = infoSpotVersionedSaverService.saveNewVersion(updatedInfoSpot);
+            if (isDeletion) {
+                // For deletion: Version entities WITHOUT copying this InfoSpot
+                logger.info("InfoSpot {} is being deleted - versioning entities without copying this spot", netexId);
 
-            incrementVersionForLinkedEntities(updatedInfoSpot);
+                // Get UNIQUE entity netexIds to version (deduplicate to avoid versioning the same entity multiple times)
+                Set<String> uniqueEntitiesToVersion = existingVersion.getLocationRefs().stream()
+                    .map(InfoSpotLocationRef::getRef)
+                    .filter(ref -> ref.contains(":Quay:") || ref.contains(":StopPlace:"))
+                    .collect(Collectors.toSet());
 
-            return updatedInfoSpot;
+                logger.info("InfoSpot {} linked to {} unique entities", netexId, uniqueEntitiesToVersion.size());
+
+                // Version each UNIQUE entity once, excluding this InfoSpot from being copied
+                for (String entityNetexId : uniqueEntitiesToVersion) {
+                    try {
+                        versionLinkedLocationExcludingInfoSpot(entityNetexId, existingVersion.getNetexId());
+                        logger.info("Versioned {} (excluded InfoSpot {} from copy)", entityNetexId, netexId);
+                    } catch (Exception e) {
+                        logger.warn("Failed to version {} during InfoSpot deletion: {}",
+                            entityNetexId, e.getMessage());
+                    }
+                }
+
+                versionIncrementor.initiateOrIncrementInfoSpot(updatedInfoSpot);
+                updatedInfoSpot = infoSpotVersionedSaverService.saveNewVersion(updatedInfoSpot);
+
+                return updatedInfoSpot;
+            } else {
+                // For create/update: Version ALL linked entities and update refs to new versions
+                // If updating existing InfoSpot, exclude it from automatic copying
+                String excludeInfoSpotForUpdate = (existingVersion != null) ? existingVersion.getNetexId() : null;
+                versionAllLinkedEntitiesAndUpdateRefs(updatedInfoSpot, excludeInfoSpotForUpdate);
+                versionIncrementor.initiateOrIncrementInfoSpot(updatedInfoSpot);
+
+                logger.info("Saving new version of InfoSpot {}", updatedInfoSpot);
+                updatedInfoSpot = infoSpotVersionedSaverService.saveNewVersion(updatedInfoSpot);
+
+                return updatedInfoSpot;
+            }
         } else {
             logger.info("No changes - InfoSpot {} NOT updated", netexId);
         }
@@ -155,7 +194,6 @@ public class InfoSpotsUpdater implements DataFetcher {
     }
 
     private boolean populateInfoSpot(Map input, InfoSpot target) {
-
         boolean isUpdated = false;
 
         if (input.containsKey(LABEL)) {
@@ -175,8 +213,17 @@ public class InfoSpotsUpdater implements DataFetcher {
         }
         if (input.containsKey(DESCRIPTION)) {
             var description = (Map) input.get(DESCRIPTION);
-            isUpdated |= !Objects.equals(description, target.getDescription());
-            target.setDescription(getEmbeddableString(description));
+            var newDescription = getEmbeddableString(description);
+            var oldDescription = target.getDescription();
+
+            // Compare the actual text values, not object references to avoid unnecessary versioning
+            String oldValue = oldDescription != null ? oldDescription.getValue() : null;
+            String newValue = newDescription != null ? newDescription.getValue() : null;
+            String oldLang = oldDescription != null ? oldDescription.getLang() : null;
+            String newLang = newDescription != null ? newDescription.getLang() : null;
+
+            isUpdated |= !Objects.equals(oldValue, newValue) || !Objects.equals(oldLang, newLang);
+            target.setDescription(newDescription);
         }
 
         if (input.containsKey(POSTER_PLACE_SIZE)) {
@@ -222,22 +269,44 @@ public class InfoSpotsUpdater implements DataFetcher {
             target.setDisplayType(displayType);
         }
 
-        // Handle location references - auto-resolve to current version
+        // Handle location references
         if (input.containsKey(INFO_SPOT_LOCATIONS)) {
-            Set<InfoSpotLocationRef> newLocationRefs = ((List<String>) input.get(INFO_SPOT_LOCATIONS)).stream()
+            List<String> locationList = (List<String>) input.get(INFO_SPOT_LOCATIONS);
+
+            Set<InfoSpotLocationRef> newLocationRefs = locationList.stream()
                     .map(this::convertLocationStringToRef)
                     .collect(Collectors.toSet());
 
-            isUpdated |= !Objects.equals(target.getLocationRefs(), newLocationRefs);
+            // Only mark as updated if the entity IDs changed, not just version numbers
+            // (version numbers change when entities are versioned in the same batch)
+            if (target.getLocationRefs() != null && !target.getLocationRefs().isEmpty()) {
+                Set<String> oldEntityIds = target.getLocationRefs().stream()
+                        .map(InfoSpotLocationRef::getRef)
+                        .collect(Collectors.toSet());
+                Set<String> newEntityIds = newLocationRefs.stream()
+                        .map(InfoSpotLocationRef::getRef)
+                        .collect(Collectors.toSet());
+
+                boolean locationsChanged = !oldEntityIds.equals(newEntityIds);
+
+                isUpdated |= locationsChanged;
+            } else {
+                // New InfoSpot or no existing refs - this is an update
+                boolean hasNewRefs = !newLocationRefs.isEmpty();
+
+                isUpdated |= hasNewRefs;
+            }
+
+            // Always update to have current version numbers
             target.setLocationRefs(newLocationRefs);
         }
 
         if (input.containsKey(OUTPUT_TYPE_POSTER)) {
             List<Map> posters = (List<Map>) input.get(OUTPUT_TYPE_POSTER);
-            if (posters != null) {
-                List<InfoSpotPosterRef> posterRefs = target.getPosters();
+            List<InfoSpotPosterRef> oldPosters = target.getPosters();
 
-                List<InfoSpotPoster> existingPosters = posterRefs.stream()
+            if (posters != null) {
+                List<InfoSpotPoster> existingPosters = oldPosters.stream()
                         .map(p -> infoSpotPosterRepository.findFirstByNetexIdOrderByVersionDesc(p.getRef()))
                         .collect(Collectors.toList());
 
@@ -247,17 +316,26 @@ public class InfoSpotsUpdater implements DataFetcher {
                         .collect(Collectors.toList());
 
                 target.setPosters(updatedPosters);
-                isUpdated = true;
-            }
-            else {
+
+                // Check if poster refs OR versions changed
+                // (poster content changes result in new version numbers even if NetEx ID stays the same)
+                Set<String> oldPosterKeys = oldPosters.stream()
+                        .map(p -> p.getRef() + "@" + p.getVersion())
+                        .collect(Collectors.toSet());
+                Set<String> newPosterKeys = updatedPosters.stream()
+                        .map(p -> p.getRef() + "@" + p.getVersion())
+                        .collect(Collectors.toSet());
+                isUpdated |= !oldPosterKeys.equals(newPosterKeys);
+            } else {
+                isUpdated |= !oldPosters.isEmpty();
                 target.setPosters(Collections.emptyList());
             }
         }
         if (input.containsKey(GEOMETRY)) {
-            target.setCentroid(geometryMapper.createGeoJsonPoint((Map) input.get(GEOMETRY)));
-            isUpdated = true;
+            org.locationtech.jts.geom.Point newGeometry = geometryMapper.createGeoJsonPoint((Map) input.get(GEOMETRY));
+            isUpdated |= !Objects.equals(target.getCentroid(), newGeometry);
+            target.setCentroid(newGeometry);
         }
-
 
         return isUpdated;
     }
@@ -369,47 +447,84 @@ public class InfoSpotsUpdater implements DataFetcher {
     }
 
     /**
-     * Increment version for linked entities when InfoSpot is updated.
+     * Version ALL linked entities before saving InfoSpot, and update locationRefs to point to new versions.
+     * This ensures that when an InfoSpot is created/updated, all linked Quays/StopPlaces get new versions
+     * and the info_spot_location junction table entries point to those new versions.
+     *
+     * @param infoSpot The InfoSpot being created/updated
+     * @param excludeInfoSpotNetexId The netexId of the InfoSpot to exclude from automatic copying (null for new InfoSpots)
      */
-    private void incrementVersionForLinkedEntities(InfoSpot savedInfoSpot) {
-        if (savedInfoSpot.getLocationRefs() == null || savedInfoSpot.getLocationRefs().isEmpty()) {
+    private void versionAllLinkedEntitiesAndUpdateRefs(InfoSpot infoSpot, String excludeInfoSpotNetexId) {
+        if (infoSpot.getLocationRefs() == null || infoSpot.getLocationRefs().isEmpty()) {
             return;
         }
 
-        logger.info("Incrementing versions for locations linked to InfoSpot {}", savedInfoSpot.getNetexId());
+        logger.info("Versioning ALL linked entities for InfoSpot before saving");
 
-        try {
-            savedInfoSpot.getLocationRefs().stream()
-                .map(InfoSpotLocationRef::getRef)
-                .filter(netexId -> netexId.contains(":Quay:") || netexId.contains(":StopPlace:"))
-                .findFirst()
-                .ifPresent(this::versionLinkedLocation);
-        } catch (Exception e) {
-            logger.error("Failed to version linked entities for InfoSpot {}: {}",
-                savedInfoSpot.getNetexId(), e.getMessage(), e);
+        // Get UNIQUE entity netexIds that need versioning (deduplicate to avoid versioning the same entity multiple times)
+        Set<String> uniqueEntitiesToVersion = infoSpot.getLocationRefs().stream()
+            .map(InfoSpotLocationRef::getRef)
+            .filter(ref -> ref.contains(":Quay:") || ref.contains(":StopPlace:"))
+            .collect(Collectors.toSet());
+
+        if (uniqueEntitiesToVersion.isEmpty()) {
+            return;
         }
+
+        logger.info("Versioning {} unique entities{}", uniqueEntitiesToVersion.size(),
+            excludeInfoSpotNetexId != null ? " (excluding InfoSpot " + excludeInfoSpotNetexId + " from copy)" : "");
+
+        // Version each UNIQUE entity once and collect the new version numbers
+        Map<String, String> netexIdToNewVersion = new HashMap<>();
+        for (String netexId : uniqueEntitiesToVersion) {
+            try {
+                String newVersionNumber = versionLinkedLocationExcludingInfoSpot(netexId, excludeInfoSpotNetexId);
+                netexIdToNewVersion.put(netexId, newVersionNumber);
+                logger.info("Versioned {} to version {}", netexId, newVersionNumber);
+            } catch (Exception e) {
+                logger.warn("Failed to version {}: {}", netexId, e.getMessage());
+            }
+        }
+
+        // Update ALL refs to point to the new versions
+        Set<InfoSpotLocationRef> updatedRefs = new HashSet<>();
+        for (InfoSpotLocationRef ref : infoSpot.getLocationRefs()) {
+            String netexId = ref.getRef();
+            if (netexIdToNewVersion.containsKey(netexId)) {
+                // Update to new version
+                updatedRefs.add(new InfoSpotLocationRef(netexId, netexIdToNewVersion.get(netexId)));
+            } else {
+                // Keep other refs (like ShelterEquipment) unchanged
+                updatedRefs.add(ref);
+            }
+        }
+
+        infoSpot.setLocationRefs(updatedRefs);
     }
 
     /**
-     * Version the linked StopPlace for a given location reference.
+     * Version the linked StopPlace for a given location reference, optionally excluding a specific InfoSpot from being copied.
+     * Used for both InfoSpot creation/update (excludeInfoSpotNetexId = null) and deletion (excludeInfoSpotNetexId = the deleted spot).
+     * Returns the new version number as a String.
      */
-    private void versionLinkedLocation(String netexId) {
+    private String versionLinkedLocationExcludingInfoSpot(String netexId, String excludeInfoSpotNetexId) {
         if (netexId.contains(":Quay:")) {
-            versionStopPlaceFromQuayReference(netexId);
+            return versionStopPlaceFromQuayReferenceForInfoSpot(netexId, excludeInfoSpotNetexId);
         } else {
             StopPlace stopPlace = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(netexId);
             if (stopPlace == null) {
                 throw new IllegalStateException("Could not find StopPlace " + netexId);
             }
-            versionStopPlace(stopPlace, null);
+            return versionStopPlaceForInfoSpot(stopPlace, null, excludeInfoSpotNetexId);
         }
     }
 
     /**
-     * Version the parent StopPlace for a Quay reference.
+     * Version the parent StopPlace for a Quay reference, FOR InfoSpot operations (includes linkage copying).
+     * Returns the new version number of the Quay as a String.
      * @throws IllegalStateException if the Quay or its parent StopPlace cannot be found
      */
-    private void versionStopPlaceFromQuayReference(String quayNetexId) {
+    private String versionStopPlaceFromQuayReferenceForInfoSpot(String quayNetexId, String excludeInfoSpotNetexId) {
         Quay quay = quayRepository.findFirstByNetexIdOrderByVersionDesc(quayNetexId);
         if (quay == null) {
             throw new IllegalStateException("Could not find Quay " + quayNetexId);
@@ -421,14 +536,19 @@ public class InfoSpotsUpdater implements DataFetcher {
         }
 
         StopPlace topLevel = getTopLevelStopPlace(parent);
-        versionStopPlace(topLevel, quayNetexId);
+        versionStopPlaceForInfoSpot(topLevel, quayNetexId, excludeInfoSpotNetexId);
+
+        // Fetch the new version of the quay after versioning
+        Quay newQuayVersion = quayRepository.findFirstByNetexIdOrderByVersionDesc(quayNetexId);
+        return String.valueOf(newQuayVersion.getVersion());
     }
 
     /**
-     * Create and save a new version of the StopPlace.
+     * Create and save a new version of the StopPlace, FOR InfoSpot operations (includes linkage copying).
+     * Returns the new version number as a String.
      */
-    private void versionStopPlace(StopPlace stopPlace, String modifiedQuayNetexId) {
-        logger.info("Incrementing version for StopPlace {}", stopPlace.getNetexId());
+    private String versionStopPlaceForInfoSpot(StopPlace stopPlace, String modifiedQuayNetexId, String excludeInfoSpotNetexId) {
+        logger.info("Incrementing version for StopPlace {} (for InfoSpot operation)", stopPlace.getNetexId());
 
         StopPlace newVersion = versionCreator.createCopy(stopPlace, StopPlace.class);
 
@@ -436,7 +556,9 @@ public class InfoSpotsUpdater implements DataFetcher {
             markQuayAsModified(newVersion, modifiedQuayNetexId);
         }
 
-        stopPlaceVersionedSaverService.saveNewVersion(stopPlace, newVersion);
+        StopPlace savedVersion = stopPlaceVersionedSaverService.saveNewVersion(stopPlace, newVersion, excludeInfoSpotNetexId);
+
+        return String.valueOf(savedVersion.getVersion());
     }
 
     /**

--- a/src/main/java/org/rutebanken/tiamat/rest/graphql/fetchers/InfoSpotsUpdater.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/graphql/fetchers/InfoSpotsUpdater.java
@@ -6,6 +6,8 @@ import graphql.schema.DataFetchingEnvironment;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -139,14 +141,51 @@ public class InfoSpotsUpdater implements DataFetcher {
         if (isUpdated) {
             authorizationService.assertAuthorized(ROLE_EDIT_STOPS, Arrays.asList(existingVersion, updatedInfoSpot));
 
-            versionIncrementor.initiateOrIncrementInfoSpot(updatedInfoSpot);
+            // Check if this is a deletion
+            boolean isDeletion = (updatedInfoSpot.getLocationRefs() == null || updatedInfoSpot.getLocationRefs().isEmpty()) 
+                && existingVersion != null 
+                && existingVersion.getLocationRefs() != null 
+                && !existingVersion.getLocationRefs().isEmpty();
 
-            logger.info("Saving new version of InfoSpot {}", updatedInfoSpot);
-            updatedInfoSpot = infoSpotVersionedSaverService.saveNewVersion(updatedInfoSpot);
+            if (isDeletion) {
+                // For deletion: Version entities WITHOUT copying this InfoSpot
+                logger.info("InfoSpot {} is being deleted - versioning entities without copying this spot", netexId);
 
-            incrementVersionForLinkedEntities(updatedInfoSpot);
+                // Get UNIQUE entity netexIds to version (deduplicate to avoid versioning the same entity multiple times)
+                Set<String> uniqueEntitiesToVersion = existingVersion.getLocationRefs().stream()
+                    .map(InfoSpotLocationRef::getRef)
+                    .filter(ref -> ref.contains(":Quay:") || ref.contains(":StopPlace:"))
+                    .collect(Collectors.toSet());
 
-            return updatedInfoSpot;
+                logger.info("InfoSpot {} linked to {} unique entities", netexId, uniqueEntitiesToVersion.size());
+
+                // Version each UNIQUE entity once, excluding this InfoSpot from being copied
+                for (String entityNetexId : uniqueEntitiesToVersion) {
+                    try {
+                        versionLinkedLocationExcludingInfoSpot(entityNetexId, existingVersion.getNetexId());
+                        logger.info("Versioned {} (excluded InfoSpot {} from copy)", entityNetexId, netexId);
+                    } catch (Exception e) {
+                        logger.warn("Failed to version {} during InfoSpot deletion: {}",
+                            entityNetexId, e.getMessage());
+                    }
+                }
+
+                versionIncrementor.initiateOrIncrementInfoSpot(updatedInfoSpot);
+                updatedInfoSpot = infoSpotVersionedSaverService.saveNewVersion(updatedInfoSpot);
+
+                return updatedInfoSpot;
+            } else {
+                // For create/update: Version ALL linked entities and update refs to new versions
+                // If updating existing InfoSpot, exclude it from automatic copying
+                String excludeInfoSpotForUpdate = (existingVersion != null) ? existingVersion.getNetexId() : null;
+                versionAllLinkedEntitiesAndUpdateRefs(updatedInfoSpot, excludeInfoSpotForUpdate);
+                versionIncrementor.initiateOrIncrementInfoSpot(updatedInfoSpot);
+
+                logger.info("Saving new version of InfoSpot {}", updatedInfoSpot);
+                updatedInfoSpot = infoSpotVersionedSaverService.saveNewVersion(updatedInfoSpot);
+
+                return updatedInfoSpot;
+            }
         } else {
             logger.info("No changes - InfoSpot {} NOT updated", netexId);
         }
@@ -155,7 +194,6 @@ public class InfoSpotsUpdater implements DataFetcher {
     }
 
     private boolean populateInfoSpot(Map input, InfoSpot target) {
-
         boolean isUpdated = false;
 
         if (input.containsKey(LABEL)) {
@@ -175,8 +213,11 @@ public class InfoSpotsUpdater implements DataFetcher {
         }
         if (input.containsKey(DESCRIPTION)) {
             var description = (Map) input.get(DESCRIPTION);
-            isUpdated |= !Objects.equals(description, target.getDescription());
-            target.setDescription(getEmbeddableString(description));
+            var newDescription = getEmbeddableString(description);
+            var oldDescription = target.getDescription();
+
+            isUpdated |= !Objects.equals(newDescription, oldDescription);
+            target.setDescription(newDescription);
         }
 
         if (input.containsKey(POSTER_PLACE_SIZE)) {
@@ -222,22 +263,44 @@ public class InfoSpotsUpdater implements DataFetcher {
             target.setDisplayType(displayType);
         }
 
-        // Handle location references - auto-resolve to current version
+        // Handle location references
         if (input.containsKey(INFO_SPOT_LOCATIONS)) {
-            Set<InfoSpotLocationRef> newLocationRefs = ((List<String>) input.get(INFO_SPOT_LOCATIONS)).stream()
+            List<String> locationList = (List<String>) input.get(INFO_SPOT_LOCATIONS);
+
+            Set<InfoSpotLocationRef> newLocationRefs = locationList.stream()
                     .map(this::convertLocationStringToRef)
                     .collect(Collectors.toSet());
 
-            isUpdated |= !Objects.equals(target.getLocationRefs(), newLocationRefs);
+            // Only mark as updated if the entity IDs changed, not just version numbers
+            // (version numbers change when entities are versioned in the same batch)
+            if (target.getLocationRefs() != null && !target.getLocationRefs().isEmpty()) {
+                Set<String> oldEntityIds = target.getLocationRefs().stream()
+                        .map(InfoSpotLocationRef::getRef)
+                        .collect(Collectors.toSet());
+                Set<String> newEntityIds = newLocationRefs.stream()
+                        .map(InfoSpotLocationRef::getRef)
+                        .collect(Collectors.toSet());
+
+                boolean locationsChanged = !oldEntityIds.equals(newEntityIds);
+
+                isUpdated |= locationsChanged;
+            } else {
+                // New InfoSpot or no existing refs - this is an update
+                boolean hasNewRefs = !newLocationRefs.isEmpty();
+
+                isUpdated |= hasNewRefs;
+            }
+
+            // Always update to have current version numbers
             target.setLocationRefs(newLocationRefs);
         }
 
         if (input.containsKey(OUTPUT_TYPE_POSTER)) {
             List<Map> posters = (List<Map>) input.get(OUTPUT_TYPE_POSTER);
-            if (posters != null) {
-                List<InfoSpotPosterRef> posterRefs = target.getPosters();
+            List<InfoSpotPosterRef> oldPosters = target.getPosters();
 
-                List<InfoSpotPoster> existingPosters = posterRefs.stream()
+            if (posters != null) {
+                List<InfoSpotPoster> existingPosters = oldPosters.stream()
                         .map(p -> infoSpotPosterRepository.findFirstByNetexIdOrderByVersionDesc(p.getRef()))
                         .collect(Collectors.toList());
 
@@ -247,17 +310,26 @@ public class InfoSpotsUpdater implements DataFetcher {
                         .collect(Collectors.toList());
 
                 target.setPosters(updatedPosters);
-                isUpdated = true;
-            }
-            else {
+
+                // Check if poster refs OR versions changed
+                // (poster content changes result in new version numbers even if NetEx ID stays the same)
+                Set<String> oldPosterKeys = oldPosters.stream()
+                        .map(p -> p.getRef() + "@" + p.getVersion())
+                        .collect(Collectors.toSet());
+                Set<String> newPosterKeys = updatedPosters.stream()
+                        .map(p -> p.getRef() + "@" + p.getVersion())
+                        .collect(Collectors.toSet());
+                isUpdated |= !oldPosterKeys.equals(newPosterKeys);
+            } else {
+                isUpdated |= !oldPosters.isEmpty();
                 target.setPosters(Collections.emptyList());
             }
         }
         if (input.containsKey(GEOMETRY)) {
-            target.setCentroid(geometryMapper.createGeoJsonPoint((Map) input.get(GEOMETRY)));
-            isUpdated = true;
+            org.locationtech.jts.geom.Point newGeometry = geometryMapper.createGeoJsonPoint((Map) input.get(GEOMETRY));
+            isUpdated |= !Objects.equals(target.getCentroid(), newGeometry);
+            target.setCentroid(newGeometry);
         }
-
 
         return isUpdated;
     }
@@ -369,47 +441,84 @@ public class InfoSpotsUpdater implements DataFetcher {
     }
 
     /**
-     * Increment version for linked entities when InfoSpot is updated.
+     * Version ALL linked entities before saving InfoSpot, and update locationRefs to point to new versions.
+     * This ensures that when an InfoSpot is created/updated, all linked Quays/StopPlaces get new versions
+     * and the info_spot_location junction table entries point to those new versions.
+     *
+     * @param infoSpot The InfoSpot being created/updated
+     * @param excludeInfoSpotNetexId The netexId of the InfoSpot to exclude from automatic copying (null for new InfoSpots)
      */
-    private void incrementVersionForLinkedEntities(InfoSpot savedInfoSpot) {
-        if (savedInfoSpot.getLocationRefs() == null || savedInfoSpot.getLocationRefs().isEmpty()) {
+    private void versionAllLinkedEntitiesAndUpdateRefs(InfoSpot infoSpot, String excludeInfoSpotNetexId) {
+        if (infoSpot.getLocationRefs() == null || infoSpot.getLocationRefs().isEmpty()) {
             return;
         }
 
-        logger.info("Incrementing versions for locations linked to InfoSpot {}", savedInfoSpot.getNetexId());
+        logger.info("Versioning ALL linked entities for InfoSpot before saving");
 
-        try {
-            savedInfoSpot.getLocationRefs().stream()
-                .map(InfoSpotLocationRef::getRef)
-                .filter(netexId -> netexId.contains(":Quay:") || netexId.contains(":StopPlace:"))
-                .findFirst()
-                .ifPresent(this::versionLinkedLocation);
-        } catch (Exception e) {
-            logger.error("Failed to version linked entities for InfoSpot {}: {}",
-                savedInfoSpot.getNetexId(), e.getMessage(), e);
+        // Get UNIQUE entity netexIds that need versioning (deduplicate to avoid versioning the same entity multiple times)
+        Set<String> uniqueEntitiesToVersion = infoSpot.getLocationRefs().stream()
+            .map(InfoSpotLocationRef::getRef)
+            .filter(ref -> ref.contains(":Quay:") || ref.contains(":StopPlace:"))
+            .collect(Collectors.toSet());
+
+        if (uniqueEntitiesToVersion.isEmpty()) {
+            return;
         }
+
+        logger.info("Versioning {} unique entities{}", uniqueEntitiesToVersion.size(),
+            excludeInfoSpotNetexId != null ? " (excluding InfoSpot " + excludeInfoSpotNetexId + " from copy)" : "");
+
+        // Version each UNIQUE entity once and collect the new version numbers
+        Map<String, String> netexIdToNewVersion = new HashMap<>();
+        for (String netexId : uniqueEntitiesToVersion) {
+            try {
+                String newVersionNumber = versionLinkedLocationExcludingInfoSpot(netexId, excludeInfoSpotNetexId);
+                netexIdToNewVersion.put(netexId, newVersionNumber);
+                logger.info("Versioned {} to version {}", netexId, newVersionNumber);
+            } catch (Exception e) {
+                logger.warn("Failed to version {}: {}", netexId, e.getMessage());
+            }
+        }
+
+        // Update ALL refs to point to the new versions
+        Set<InfoSpotLocationRef> updatedRefs = new HashSet<>();
+        for (InfoSpotLocationRef ref : infoSpot.getLocationRefs()) {
+            String netexId = ref.getRef();
+            if (netexIdToNewVersion.containsKey(netexId)) {
+                // Update to new version
+                updatedRefs.add(new InfoSpotLocationRef(netexId, netexIdToNewVersion.get(netexId)));
+            } else {
+                // Keep other refs (like ShelterEquipment) unchanged
+                updatedRefs.add(ref);
+            }
+        }
+
+        infoSpot.setLocationRefs(updatedRefs);
     }
 
     /**
-     * Version the linked StopPlace for a given location reference.
+     * Version the linked StopPlace for a given location reference, optionally excluding a specific InfoSpot from being copied.
+     * Used for both InfoSpot creation/update (excludeInfoSpotNetexId = null) and deletion (excludeInfoSpotNetexId = the deleted spot).
+     * Returns the new version number as a String.
      */
-    private void versionLinkedLocation(String netexId) {
+    private String versionLinkedLocationExcludingInfoSpot(String netexId, String excludeInfoSpotNetexId) {
         if (netexId.contains(":Quay:")) {
-            versionStopPlaceFromQuayReference(netexId);
+            return versionStopPlaceFromQuayReferenceForInfoSpot(netexId, excludeInfoSpotNetexId);
         } else {
             StopPlace stopPlace = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(netexId);
             if (stopPlace == null) {
                 throw new IllegalStateException("Could not find StopPlace " + netexId);
             }
-            versionStopPlace(stopPlace, null);
+            return versionStopPlaceForInfoSpot(stopPlace, null, excludeInfoSpotNetexId);
         }
     }
 
     /**
-     * Version the parent StopPlace for a Quay reference.
+     * Version the parent StopPlace for a Quay reference, FOR InfoSpot operations (includes linkage copying).
+     * Returns the new version number of the Quay as a String.
      * @throws IllegalStateException if the Quay or its parent StopPlace cannot be found
      */
-    private void versionStopPlaceFromQuayReference(String quayNetexId) {
+    private String versionStopPlaceFromQuayReferenceForInfoSpot(String quayNetexId, String excludeInfoSpotNetexId) {
         Quay quay = quayRepository.findFirstByNetexIdOrderByVersionDesc(quayNetexId);
         if (quay == null) {
             throw new IllegalStateException("Could not find Quay " + quayNetexId);
@@ -421,14 +530,19 @@ public class InfoSpotsUpdater implements DataFetcher {
         }
 
         StopPlace topLevel = getTopLevelStopPlace(parent);
-        versionStopPlace(topLevel, quayNetexId);
+        versionStopPlaceForInfoSpot(topLevel, quayNetexId, excludeInfoSpotNetexId);
+
+        // Fetch the new version of the quay after versioning
+        Quay newQuayVersion = quayRepository.findFirstByNetexIdOrderByVersionDesc(quayNetexId);
+        return String.valueOf(newQuayVersion.getVersion());
     }
 
     /**
-     * Create and save a new version of the StopPlace.
+     * Create and save a new version of the StopPlace, FOR InfoSpot operations (includes linkage copying).
+     * Returns the new version number as a String.
      */
-    private void versionStopPlace(StopPlace stopPlace, String modifiedQuayNetexId) {
-        logger.info("Incrementing version for StopPlace {}", stopPlace.getNetexId());
+    private String versionStopPlaceForInfoSpot(StopPlace stopPlace, String modifiedQuayNetexId, String excludeInfoSpotNetexId) {
+        logger.info("Incrementing version for StopPlace {} (for InfoSpot operation)", stopPlace.getNetexId());
 
         StopPlace newVersion = versionCreator.createCopy(stopPlace, StopPlace.class);
 
@@ -436,7 +550,9 @@ public class InfoSpotsUpdater implements DataFetcher {
             markQuayAsModified(newVersion, modifiedQuayNetexId);
         }
 
-        stopPlaceVersionedSaverService.saveNewVersion(stopPlace, newVersion);
+        StopPlace savedVersion = stopPlaceVersionedSaverService.saveNewVersion(stopPlace, newVersion, excludeInfoSpotNetexId);
+
+        return String.valueOf(savedVersion.getVersion());
     }
 
     /**

--- a/src/main/java/org/rutebanken/tiamat/rest/graphql/fetchers/QuayInfoSpotsFetcher.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/graphql/fetchers/QuayInfoSpotsFetcher.java
@@ -23,8 +23,9 @@ public class QuayInfoSpotsFetcher implements DataFetcher<List<InfoSpot>> {
 
         Quay quay = environment.getSource();
 
-        logger.info("Fetching info spots for quay {}", quay.getNetexId());
+        logger.info("Fetching info spots for quay {} version {}", quay.getNetexId(), quay.getVersion());
 
-        return infoSpotRepository.findForAssociation(quay.getNetexId());
+        // Use version-aware filtering to only return InfoSpots linked to this specific version
+        return infoSpotRepository.findForAssociationWithVersion(quay.getNetexId(), quay.getVersion());
     }
 }

--- a/src/main/java/org/rutebanken/tiamat/rest/graphql/fetchers/StopPlaceInfoSpotsFetcher.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/graphql/fetchers/StopPlaceInfoSpotsFetcher.java
@@ -24,8 +24,9 @@ public class StopPlaceInfoSpotsFetcher implements DataFetcher<List<InfoSpot>> {
 
         StopPlace stopPlace = environment.getSource();
 
-        logger.info("Fetching info spots for stop place {}", stopPlace.getNetexId());
+        logger.info("Fetching info spots for stop place {} version {}", stopPlace.getNetexId(), stopPlace.getVersion());
 
-        return infoSpotRepository.findForAssociation(stopPlace.getNetexId());
+        // Use version-aware filtering to only return InfoSpots linked to this specific version
+        return infoSpotRepository.findForAssociationWithVersion(stopPlace.getNetexId(), stopPlace.getVersion());
     }
 }

--- a/src/main/java/org/rutebanken/tiamat/rest/graphql/mappers/EmbeddableMultilingualStringMapper.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/graphql/mappers/EmbeddableMultilingualStringMapper.java
@@ -27,7 +27,12 @@ public class EmbeddableMultilingualStringMapper {
 
     public static EmbeddableMultilingualString getEmbeddableString(Map map) {
         if (map != null) {
-            return new EmbeddableMultilingualString((String) map.get(VALUE), (String) map.get(LANG));
+            String value = (String) map.get(VALUE);
+            String lang = (String) map.get(LANG);
+            if (value == null && lang == null) {
+                return null;
+            }
+            return new EmbeddableMultilingualString(value, lang);
         }
         return null;
     }

--- a/src/main/java/org/rutebanken/tiamat/service/InfoSpotLinkageMaintainer.java
+++ b/src/main/java/org/rutebanken/tiamat/service/InfoSpotLinkageMaintainer.java
@@ -1,0 +1,105 @@
+package org.rutebanken.tiamat.service;
+
+import org.rutebanken.tiamat.model.InfoSpot;
+import org.rutebanken.tiamat.model.InfoSpotLocationRef;
+import org.rutebanken.tiamat.model.Quay;
+import org.rutebanken.tiamat.model.StopPlace;
+import org.rutebanken.tiamat.repository.InfoSpotRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Service responsible for maintaining InfoSpot linkages when entities are versioned.
+ * When a StopPlace/Quay is versioned, this service copies all InfoSpot linkages
+ * from the old version to the new version, so InfoSpots appear on both versions.
+ */
+@Service
+@Transactional
+public class InfoSpotLinkageMaintainer {
+
+    private static final Logger logger = LoggerFactory.getLogger(InfoSpotLinkageMaintainer.class);
+
+    @Autowired
+    private InfoSpotRepository infoSpotRepository;
+
+    /**
+     * Copy InfoSpot linkages when a StopPlace is versioned, optionally excluding a specific InfoSpot.
+     * Used when deleting an InfoSpot (pass excludeInfoSpotNetexId) or copying normally (pass null).
+     * This ensures InfoSpots appear on both the old and new versions.
+     */
+    public void maintainInfoSpotLinkagesExcluding(StopPlace oldStopPlace, StopPlace newStopPlace, String excludeInfoSpotNetexId) {
+        if (oldStopPlace == null || newStopPlace == null) {
+            return;
+        }
+
+        logger.info("Maintaining InfoSpot linkages from StopPlace {}:{} to {}:{}",
+            oldStopPlace.getNetexId(), oldStopPlace.getVersion(),
+            newStopPlace.getNetexId(), newStopPlace.getVersion());
+
+        // Copy for StopPlace
+        copyInfoSpotLinksToNewVersion(oldStopPlace.getNetexId(), oldStopPlace.getVersion(),
+            newStopPlace.getVersion(), excludeInfoSpotNetexId);
+
+        // Copy for all Quays
+        if (oldStopPlace.getQuays() != null && newStopPlace.getQuays() != null) {
+            for (Quay oldQuay : oldStopPlace.getQuays()) {
+                for (Quay newQuay : newStopPlace.getQuays()) {
+                    if (oldQuay.getNetexId().equals(newQuay.getNetexId()) && 
+                        oldQuay.getVersion() != newQuay.getVersion()) {
+                        copyInfoSpotLinksToNewVersion(oldQuay.getNetexId(), oldQuay.getVersion(),
+                            newQuay.getVersion(), excludeInfoSpotNetexId);
+                    }
+                }
+            }
+        }
+
+        // Copy for children (terminals)
+        if (oldStopPlace.getChildren() != null && newStopPlace.getChildren() != null) {
+            for (StopPlace oldChild : oldStopPlace.getChildren()) {
+                for (StopPlace newChild : newStopPlace.getChildren()) {
+                    if (oldChild.getNetexId().equals(newChild.getNetexId())) {
+                        maintainInfoSpotLinkagesExcluding(oldChild, newChild, excludeInfoSpotNetexId);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Copy InfoSpot linkages from one entity version to another.
+     * Finds all InfoSpots linked to the old version and adds the new version to their locationRefs.
+     */
+    private void copyInfoSpotLinksToNewVersion(String netexId, Long oldVersion, Long newVersion, String excludeInfoSpotNetexId) {
+        List<InfoSpot> linkedSpots = infoSpotRepository.findForAssociationWithVersion(netexId, oldVersion);
+        logger.debug("Found {} InfoSpots linked to {}:{}", linkedSpots.size(), netexId, oldVersion);
+
+        for (InfoSpot spot : linkedSpots) {
+            // Skip the excluded InfoSpot (used when deleting)
+            if (excludeInfoSpotNetexId != null && excludeInfoSpotNetexId.equals(spot.getNetexId())) {
+                logger.debug("Skipping InfoSpot {} (excluded from copy)", spot.getNetexId());
+                continue;
+            }
+
+            // Get the managed collection
+            Set<InfoSpotLocationRef> refs = spot.getLocationRefs();
+            if (refs == null) {
+                refs = new HashSet<>();
+                spot.setLocationRefs(refs);
+            }
+
+            // Add the new linkage - this is additive, doesn't remove old refs
+            InfoSpotLocationRef newRef = new InfoSpotLocationRef(netexId, String.valueOf(newVersion));
+            refs.add(newRef);
+        }
+
+        logger.debug("Copied {} InfoSpot linkages from {}:{} to {}:{}",
+            linkedSpots.size(), netexId, oldVersion, netexId, newVersion);
+    }
+}

--- a/src/main/java/org/rutebanken/tiamat/versioning/save/StopPlaceVersionedSaverService.java
+++ b/src/main/java/org/rutebanken/tiamat/versioning/save/StopPlaceVersionedSaverService.java
@@ -29,6 +29,7 @@ import org.rutebanken.tiamat.model.StopPlace;
 import org.rutebanken.tiamat.model.TariffZoneRef;
 import org.rutebanken.tiamat.repository.StopPlaceRepository;
 import org.rutebanken.tiamat.repository.reference.ReferenceResolver;
+import org.rutebanken.tiamat.service.InfoSpotLinkageMaintainer;
 import org.rutebanken.tiamat.service.TariffZonesLookupService;
 import org.rutebanken.tiamat.service.TopographicPlaceLookupService;
 import org.rutebanken.tiamat.service.metrics.PrometheusMetricsService;
@@ -134,6 +135,9 @@ public class StopPlaceVersionedSaverService {
     @Autowired
     private PrometheusMetricsService prometheusMetricsService;
 
+    @Autowired
+    private InfoSpotLinkageMaintainer infoSpotLinkageMaintainer;
+
     public StopPlaceVersionedSaverService() {
         this.quayDiffConfig = org.rutebanken.tiamat.diff.generic.GenericDiffConfig.builder()
             .identifiers(Sets.newHashSet("netexId", "ref"))
@@ -163,7 +167,19 @@ public class StopPlaceVersionedSaverService {
         return saveNewVersion(null, newVersion);
     }
     
+    /**
+     * Save a new version of a StopPlace, optionally excluding a specific InfoSpot from being copied.
+     * This is used when updating/deleting an InfoSpot - the old version should not be copied to the new entity version.
+     */
+    public StopPlace saveNewVersion(StopPlace existingVersion, StopPlace newVersion, String excludeInfoSpotNetexId) {
+        return saveNewVersion(existingVersion, newVersion, Instant.now(), new HashSet<>(), excludeInfoSpotNetexId);
+    }
+
     public StopPlace saveNewVersion(StopPlace existingVersion, StopPlace newVersion, Instant defaultValidFrom, Set<String> childStopsUpdated) {
+        return saveNewVersion(existingVersion, newVersion, defaultValidFrom, childStopsUpdated, null);
+    }
+
+    public StopPlace saveNewVersion(StopPlace existingVersion, StopPlace newVersion, Instant defaultValidFrom, Set<String> childStopsUpdated, String excludeInfoSpotNetexId) {
 
         versionValidator.validate(existingVersion, newVersion);
 
@@ -276,6 +292,26 @@ public class StopPlaceVersionedSaverService {
         }
         newVersion = stopPlaceRepository.save(newVersion);
         logger.debug("Saved stop place with id: {} and childs {}", newVersion.getId(), newVersion.getChildren().stream().map(ch -> ch.getId()).collect(toList()));
+
+        // Copy InfoSpot linkages from old version to new version (with optional exclusion)
+        if (existingVersion != null) {
+            infoSpotLinkageMaintainer.maintainInfoSpotLinkagesExcluding(existingVersion, newVersion, excludeInfoSpotNetexId);
+        }
+
+        if (newVersion.getChildren() != null) {
+            newVersion.getChildren().forEach(child -> {
+                StopPlace previousChildVersion = stopPlaceRepository.findFirstByNetexIdAndVersion(
+                    child.getNetexId(),
+                    child.getVersion() - 1
+                );
+                if (previousChildVersion != null) {
+                    logger.debug("Maintaining InfoSpot linkages for child {} from version {} to version {}",
+                        child.getNetexId(), previousChildVersion.getVersion(), child.getVersion());
+                    infoSpotLinkageMaintainer.maintainInfoSpotLinkagesExcluding(
+                        previousChildVersion, child, excludeInfoSpotNetexId);
+                }
+            });
+        }
 
         updateParentSiteRefsForChildren(newVersion);
 

--- a/src/main/java/org/rutebanken/tiamat/versioning/save/StopPlaceVersionedSaverService.java
+++ b/src/main/java/org/rutebanken/tiamat/versioning/save/StopPlaceVersionedSaverService.java
@@ -29,6 +29,7 @@ import org.rutebanken.tiamat.model.StopPlace;
 import org.rutebanken.tiamat.model.TariffZoneRef;
 import org.rutebanken.tiamat.repository.StopPlaceRepository;
 import org.rutebanken.tiamat.repository.reference.ReferenceResolver;
+import org.rutebanken.tiamat.service.InfoSpotLinkageMaintainer;
 import org.rutebanken.tiamat.service.TariffZonesLookupService;
 import org.rutebanken.tiamat.service.TopographicPlaceLookupService;
 import org.rutebanken.tiamat.service.metrics.PrometheusMetricsService;
@@ -134,6 +135,9 @@ public class StopPlaceVersionedSaverService {
     @Autowired
     private PrometheusMetricsService prometheusMetricsService;
 
+    @Autowired
+    private InfoSpotLinkageMaintainer infoSpotLinkageMaintainer;
+
     public StopPlaceVersionedSaverService() {
         this.quayDiffConfig = org.rutebanken.tiamat.diff.generic.GenericDiffConfig.builder()
             .identifiers(Sets.newHashSet("netexId", "ref"))
@@ -163,7 +167,19 @@ public class StopPlaceVersionedSaverService {
         return saveNewVersion(null, newVersion);
     }
     
+    /**
+     * Save a new version of a StopPlace, optionally excluding a specific InfoSpot from being copied.
+     * This is used when updating/deleting an InfoSpot - the old version should not be copied to the new entity version.
+     */
+    public StopPlace saveNewVersion(StopPlace existingVersion, StopPlace newVersion, String excludeInfoSpotNetexId) {
+        return saveNewVersion(existingVersion, newVersion, Instant.now(), new HashSet<>(), excludeInfoSpotNetexId);
+    }
+
     public StopPlace saveNewVersion(StopPlace existingVersion, StopPlace newVersion, Instant defaultValidFrom, Set<String> childStopsUpdated) {
+        return saveNewVersion(existingVersion, newVersion, defaultValidFrom, childStopsUpdated, null);
+    }
+
+    public StopPlace saveNewVersion(StopPlace existingVersion, StopPlace newVersion, Instant defaultValidFrom, Set<String> childStopsUpdated, String excludeInfoSpotNetexId) {
 
         versionValidator.validate(existingVersion, newVersion);
 
@@ -276,6 +292,11 @@ public class StopPlaceVersionedSaverService {
         }
         newVersion = stopPlaceRepository.save(newVersion);
         logger.debug("Saved stop place with id: {} and childs {}", newVersion.getId(), newVersion.getChildren().stream().map(ch -> ch.getId()).collect(toList()));
+
+        // Copy InfoSpot linkages from old version to new version (with optional exclusion)
+        if (existingVersion != null) {
+            infoSpotLinkageMaintainer.maintainInfoSpotLinkagesExcluding(existingVersion, newVersion, excludeInfoSpotNetexId);
+        }
 
         updateParentSiteRefsForChildren(newVersion);
 


### PR DESCRIPTION
- Fetch info spots with correct version
- Info spot refs got versions from previous quay version while it got bumped up, fixed to get new quay version
- Better checking in changes to avoid parent versioning when info spot had no actual changes

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-tiamat/126)
<!-- Reviewable:end -->
